### PR TITLE
Reorganize project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,12 @@ Repository instructions for AI coding agents working on this project.
 - When touching confusing code, clarify terminology near the code or in the relevant docs.
 - Keep comments concise: where data comes from, where it goes, what moment in the flow it belongs to, and why the boundary exists.
 - Use `docs/architecture.md` for stable architecture narrative.
+- Use `docs/runtime-lifecycle.md` for bootstrap wiring, ownership boundaries, and runtime data-flow diagrams.
+- Use `docs/plugin-flow.md` for plugin realtime/audio callback details.
 - Use `docs/development.md` for build, lint, format, and run commands.
 - Use `docs/native-midi-flow.md` for native MIDI and desktop flow details.
+- Use `docs/algorithm-archaeology.md` for algorithm history, interval-domain terminology, and histogram reasoning.
+- Use `docs/lint-exceptions.md` when reviewing or changing existing `#[allow(...)]` lint exceptions.
 - Use `docs/superpowers/plans/` for stepwise migration plans.
 
 ## Current Direction

--- a/README.md
+++ b/README.md
@@ -1,54 +1,60 @@
-# Midi BPM detection
+# MIDI BPM Detection
 
-The purpose of this project is to let you play a midi instrument without worrying about being on time when recording,
-instead, the tempo at which you play is evaluated in real time and injected into the host DAW ; doing so, hopefully,
-your
-recording will nicely fit into a loop without needing adjustments.
+MIDI BPM Detection estimates tempo from incoming MIDI note-on events while you play. The goal is to let a musician record
+freely, infer the tempo from the performance in realtime, and feed that tempo back to the host DAW so the recording can
+fit a loop with less manual adjustment.
 
-The plugin does so by comparing all combinations of intervals between notes and finding regularities, accounting for a
-range of tempo configured by the user, a margin of error and other configurable parameters.
+The detector compares intervals between recent notes, scores likely beat durations, and exposes both a single estimated
+BPM and a histogram that shows competing tempo candidates. The histogram is important: it makes the guess inspectable
+instead of hiding the model behind one number.
 
-The screenshot below shows the different parameters and the realtime representation of the evaluation. The highest curve
-will be the most probable BPM.
+The screenshot below shows the plugin/demo UI with detection parameters and the realtime histogram. The strongest peak is
+the current most likely BPM.
 
 <a href="https://valsteen.github.io/midi_bpm_detection/"><img src="screenshot.png" alt="screenshot"></a>
 
-The process is indeed not perfect and parameters must be tweaked depending on the play style.
+Try the browser demo: https://valsteen.github.io/midi_bpm_detection/
 
-WASM Demo: https://valsteen.github.io/midi_bpm_detection/
+## Project Shape
 
-## State of the project
+This is an experimental Rust project with three runtime modes:
 
-This is in a very early works-on-my-machine state and will require further cleanup and testing.
+- `plugin`: the CLAP/VST3 target intended to run inside a DAW. This is the production constraint.
+- `desktop`: a native GUI app used for local iteration and native MIDI experiments.
+- `wasm`: a browser demo that makes the detector easy to try and share.
 
-In the meantime curious developers may simply have a look at the model, the core of the BPM evaluation can be found in
-[midi/bpm_detection.rs](crates/bpm_detection_core/src/bpm_detection.rs).
+The project is still a work in progress. Tempo detection depends on play style and parameter tuning, and the host tempo
+feedback path is currently shaped around Bitwig integration.
 
-Development build, formatter, linter, plugin, and WASM commands are documented in
-[docs/development.md](docs/development.md).
+The core BPM evaluation lives in
+[crates/bpm_detection_core/src/bpm_detection.rs](crates/bpm_detection_core/src/bpm_detection.rs).
 
-A first-pass architecture map is available in [docs/architecture.md](docs/architecture.md).
+## Documentation
 
-## Building and using the Clap/VST3 Plugin
+- [Architecture](docs/architecture.md): crate map, runtime modes, and architecture boundaries.
+- [Runtime lifecycle](docs/runtime-lifecycle.md): bootstrap wiring and data flows between plugin, desktop, WASM, GUI, and
+  BPM detection components.
+- [Plugin flow](docs/plugin-flow.md): host buffer processing, realtime handoff, background work, and tempo feedback.
+- [Native MIDI flow](docs/native-midi-flow.md): desktop MIDI service, controller boundary, worker messages, and native
+  MIDI output ownership.
+- [Algorithm archaeology](docs/algorithm-archaeology.md): the original tempo-detection idea and why the histogram exists.
+- [Development commands](docs/development.md): setup, formatting, checking, plugin bundling, and WASM demo commands.
 
-This has not been thoroughly tested and only on Mac.
+## Building And Using The CLAP/VST3 Plugin
 
-The process should be:
+Bundle the plugin with:
 
 ```shell
 cargo xtask bundle midi-bpm-detector-plugin --release
 ```
 
-The plugin in two formats should be available under `target/bundled` , as `midi-bpm-detector-plugin.clap` and
+The plugin artifacts are written under `target/bundled` as `midi-bpm-detector-plugin.clap` and
 `midi-bpm-detector-plugin.vst3`.
 
-To make it really useful, it has to control the tempo of the host DAW. Plugins don't have this capability so there is
-the companion controller script for Bitwig:
+To control the host DAW tempo, the plugin needs a companion controller integration. The current Bitwig controller script
+is here:
 
 https://github.com/valsteen/bitwig-beat-detection-controller
 
-Just make sure to load the controller script, then add the Clap plugin to the track on which you'll do your midi
-recording.
-Upon selecting the plugin, the controller script will detect it and start communicating with it ( the "DAW Port"
-parameter will change, they will communicate via TCP from there ).
-Then set the "Send tempo" to "On".
+Load the controller script, add the CLAP plugin to the MIDI track, and select the plugin. The controller should detect it
+and set the plugin's `DAW Port` parameter for local TCP communication. Then enable `Send tempo`.

--- a/crates/midi-bpm-detector-plugin/README.md
+++ b/crates/midi-bpm-detector-plugin/README.md
@@ -1,9 +1,7 @@
-# Midi BPM Detector
+# MIDI BPM Detector Plugin
 
-## Building
+This crate builds the CLAP/VST3 plugin runtime for MIDI BPM Detection.
 
-After installing [Rust](https://rustup.rs/), you can compile Midi BPM Detector as follows:
-
-```shell
-cargo xtask bundle midi-bpm-detector-plugin --release
-```
+Start with the repository [README](../../README.md) for the project overview and supported runtime modes. Plugin-specific
+runtime details live in [plugin flow](../../docs/plugin-flow.md), and build commands live in
+[development commands](../../docs/development.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -278,35 +278,15 @@ constraints:
 These constraints should be treated as design rules when changing plugin-mode code. If a change requires allocation,
 blocking I/O, lock contention, or unbounded work, it belongs outside the realtime callback.
 
-## Forked Plugin Dependencies
+## Plugin Dependency Notes
 
 The plugin path currently uses forks of `nih-plug` and `egui-baseview`. This should be treated as a pragmatic extension
 of upstream crates, not as a permanent divergence goal.
 
-The `nih-plug` fork currently carries four kinds of changes.
-
-First, the fork changes `TaskExecutor` from `Fn` to `FnMut`. This project hands NIH-plug a closure that owns the plugin's
-background executor and calls `TaskExecutor::execute(&mut self, task)`. That executor mutates the BPM model, shared config,
-GUI remote, DAW tempo connection, and ring-buffer receiver. A plain `Fn` executor cannot express that owned mutable state
-without introducing extra interior-mutability ceremony around the whole executor.
-
-Second, the fork keeps the plugin editor aligned with the shared GUI stack. `nih_plug_egui` is pointed at the local
-`egui-baseview` fork, now on the same egui generation as the desktop and WASM GUI. The fork also removes NIH-plug-egui's
-unconditional `request_repaint()` in the editor update loop because this project has explicit repaint paths through
-`GuiRemote`; always repainting kept the editor active even while visually idle.
-
-Third, the fork carries small compatibility fixes required by the newer egui generation, including the
-`ResizableWindow` integration update and one explicit `f32` literal in NIH-plug-egui widget code.
-
-Fourth, the fork restores exhaustive matching for `NoteEvent` and adds `NoteEvent::UnsupportedMidi` as an explicit raw
-MIDI escape hatch. That variant is for compact MIDI-shaped messages NIH-plug does not model as first-class events, while
-real SysEx messages starting with `0xf0` still use NIH-plug's `SysExMessage` path. This keeps the low-level passthrough
-feature available for adjacent controller/host experiments without keeping the old SysEx-tempo hack in this project.
-
-The abandoned experiment was to send tempo data through SysEx or SysEx-like MIDI routing so a DAW-side controller script
-could read it. Host behavior around SysEx routing was too inconsistent and under-documented for that path to be a stable
-feature. The standalone binary also uses NIH-plug's public standalone entry point now, so the fork no longer exposes
-private standalone wrapper modules.
+The fork exists for plugin/editor compatibility work that the project currently needs: mutable background task execution,
+alignment with the shared egui stack, small compatibility fixes for the current egui generation, and a compact raw-MIDI
+escape hatch. The abandoned SysEx-tempo experiment should not be treated as the production integration strategy; plugin
+tempo feedback now uses the localhost controller bridge described in [plugin flow](plugin-flow.md).
 
 Forks should follow a forward-only policy:
 
@@ -315,9 +295,9 @@ Forks should follow a forward-only policy:
 - pin commits in this repository so plugin builds are reproducible;
 - periodically check whether upstream has caught up enough to drop the fork or reduce its diff.
 
-The egui/wgpu update that removed `block v0.1.6` follows this policy. Instead of patching `block`, `metal`, or
-`wgpu-hal` 25, the project moved to the upstream generation where Metal uses `block2`/`objc2`. The only fork updates
-needed were compatibility bumps so the plugin editor and shared desktop/WASM GUI could stay on the same egui generation.
+The dependency rule is forward movement over patching obsolete transitive crates. For example, the egui/wgpu update that
+removed `block v0.1.6` moved to the upstream generation where Metal uses `block2`/`objc2`, then kept fork changes limited
+to compatibility work needed by the plugin editor and shared desktop/WASM GUI.
 
 ## Configuration Shape
 
@@ -347,22 +327,17 @@ Both surfaces need to stay in sync, but blindly reflecting every update in both 
 the DAW updates the plugin, the GUI mirrors the change, the GUI writes the value back through the plugin setter, and the
 host treats that as another user edit.
 
-The current plugin code handles this by tagging config tasks with `UpdateOrigin::Daw` or `UpdateOrigin::Gui`. The origin
-decides which side is considered authoritative for that update and whether the other side must refresh its local config.
-This is intentional architecture, but some surrounding code should be treated as archeology from that struggle:
-
-- startup forces an initial parameter sync so saved DAW parameters populate the GUI config;
-- `gui_must_update_config` tells the editor to reload config after DAW-originated changes;
-- GUI-originated changes are delayed and batched before they reach the background task executor;
-- static and dynamic config updates use similar but not identical refresh/recompute paths.
+The current plugin code handles this by tagging config tasks with `UpdateOrigin::Daw` or `UpdateOrigin::Gui`. The
+origin decides which side is considered authoritative for that update and whether the other side must refresh its local
+config. The detailed host-origin and GUI-origin flows live in [runtime lifecycle](runtime-lifecycle.md).
 
 This area is a likely refactor target. The desired end state is a small, explicit parameter-sync protocol that documents
 which surface owns an update, which side must refresh, and when BPM recomputation is required. That protocol should make
 feedback-loop prevention obvious instead of depending on scattered flags and timing behavior.
 
-## Validation Notes
+## Open Architecture Questions
 
-These points are worth validating before writing deeper runtime diagrams:
+These points are worth re-checking when changing ownership, communication, or runtime boundaries:
 
 - `bpm_detection_core` now owns the algorithm/config/core-note surface, while `bpm_detection_midi` owns native MIDI
   service integration. If core grows again, keep checking whether new code belongs to the algorithm model, a
@@ -375,8 +350,8 @@ These points are worth validating before writing deeper runtime diagrams:
   workaround-shaped code from avoiding DAW/GUI feedback loops. Review this before documenting it as final design.
 - Prefer typed peer boundaries wired at bootstrap over adding more cases to a runtime-wide event bus. If a bootstrap
   section starts looking like a hidden orchestrator, split the peer protocol instead of centralizing more behavior.
-- [Runtime lifecycle](runtime-lifecycle.md) is the first data-flow/thread-boundary diagram. More detailed sequence
-  diagrams may still be useful later for flows that need code-level precision.
+- [Runtime lifecycle](runtime-lifecycle.md) is the authoritative data-flow/thread-boundary diagram. More detailed
+  sequence diagrams may still be useful later for flows that need code-level precision.
 
 ## Detailed Flow Notes
 

--- a/docs/lint-exceptions.md
+++ b/docs/lint-exceptions.md
@@ -13,7 +13,7 @@ Policy:
 
 ## Audit Notes
 
-Reviewed on 2026-06-21 while removing stale exceptions.
+Reviewed on 2026-06-24 against the tracked crates while keeping the 2026-06-21 cleanup notes below.
 
 Removed during this audit:
 
@@ -30,7 +30,7 @@ These are the main cleanup risk. They are not immediate behavior bugs, but they 
 crates:
 
 - `missing_panics_doc`, `missing_errors_doc`, `module_name_repetitions`
-  - Present in core, GUI, desktop, WASM, sync, parameter, errors, build, and native MIDI crates.
+  - Present across core, GUI, WASM, sync, parameter, errors, build, native MIDI, and plugin crates.
   - Mostly documentation/API-style noise from `clippy::pedantic`.
   - Acceptable temporarily, but should not be copied to new crates without confirmation.
 - Cast lint groups such as `cast_possible_truncation`, `cast_sign_loss`, `cast_possible_wrap`, and
@@ -38,6 +38,9 @@ crates:
   - Present mainly in core numeric code, GUI rendering, parameter conversion, plugin code, and WASM input adapters.
   - Higher-risk than doc/style exceptions because they can hide real overflow or precision bugs.
   - Keep reviewing these opportunistically when touching numeric conversion code.
+- `similar_names`
+  - Present in the plugin crate.
+  - Treat this as readability debt in a dense integration layer, not as permission to introduce confusing local names.
 
 ### Local Exceptions That Look Intentional
 
@@ -58,8 +61,7 @@ crates:
 These exceptions are signs of code that may deserve splitting or clearer names:
 
 - `too_many_lines`
-  - Present in BPM scoring, native worker loop, plugin task executor, plugin parameter construction, and desktop
-    bootstrap/UI integration code.
+  - Present in BPM scoring, native worker loop, plugin task executor, and plugin parameter construction.
   - These are complexity markers. Refactor when working in those areas, but avoid mechanical extraction that hides the
     flow.
 - `too_many_arguments`

--- a/docs/native-midi-flow.md
+++ b/docs/native-midi-flow.md
@@ -66,9 +66,9 @@ The native desktop binary starts egui directly and keeps MIDI work behind explic
 - The command worker starts only after the controller exists, so queued callbacks never operate on an unset controller.
 - `AppBuilderShell` receives `DesktopBaseConfig` only after the controller/runtime are ready.
 
-## Proposed Desktop Controller Boundary
+## Desktop Controller Boundary
 
-The future desktop GUI needs an integration layer above `gui` and `bpm_detection_midi`.
+The desktop GUI uses an integration layer above `gui` and `bpm_detection_midi`.
 
 That layer should depend on both crates, but neither shared crate should depend back on it:
 
@@ -79,7 +79,7 @@ That layer should depend on both crates, but neither shared crate should depend 
 - The desktop controller should own the relationship between the two: native device selection, selected input lifetime,
   MIDI display/debug state if still useful, config propagation, and desktop-only MIDI side effects.
 
-The controller should expose capabilities that map to user intent rather than TUI actions:
+The controller exposes capabilities that map to user intent rather than TUI actions:
 
 ```text
 DesktopController


### PR DESCRIPTION
## Summary
- rewrite the root README as the GitHub landing page for the project
- clarify the docs map in AGENTS.md and reduce duplication in the plugin README
- consolidate architecture details into the lifecycle/plugin flow docs and refresh stale native/lint documentation wording

## Verification
- git diff --check
- rg -n "[[:space:]]$" README.md AGENTS.md docs/*.md crates/midi-bpm-detector-plugin/README.md
- scripts/dev.sh test-native