### PR TITLE
Name plugin parameter sync origin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Repository instructions for AI coding agents working on this project.
 - `rustfmt` is intentionally run with nightly.
 - Keep `clippy::pedantic` enabled at workspace level.
 - Prefer type-safe representations over sentinel values. If a value has an unset/error/special state, encode that state in the type.
+- Avoid false reuse. If a new helper/protocol makes callers prove a variant is impossible with `unreachable!`, `debug_assert`, or "cannot happen here" comments, split the type or move the shared representation later in the flow. If a caller already knows the only valid case, keep the direct code there instead of routing through a generic policy method.
+- Before keeping a new abstraction, check that it models production code that exists now. Do not add variants, traits, or policy layers for possible future cases; add them when the future case exists.
 - Before adding custom generic utility code, evaluate existing crates for the job. If a crate is close but awkward, document the mismatch.
 - Avoid generic `utils` crates. Put reusable primitives in focused crates that match their dependency surface, such as synchronization primitives in `sync`.
 - Keep dependency versions moving forward. Prefer updating/forking the dependency that pins an old version over patching an obsolete transitive crate.
@@ -48,6 +50,8 @@ Repository instructions for AI coding agents working on this project.
 
 - When touching confusing code, clarify terminology near the code or in the relevant docs.
 - Keep comments concise: where data comes from, where it goes, what moment in the flow it belongs to, and why the boundary exists.
+- When documenting refactors, do not describe unchanged behavior as "restored" or "now" happening. Say that the behavior is preserved and name only the structural change.
+- When documenting refactor targets, include the non-goal or stop condition so future agents do not expand the note into speculative architecture work.
 - Use `docs/architecture.md` for stable architecture narrative.
 - Use `docs/runtime-lifecycle.md` for bootstrap wiring, ownership boundaries, and runtime data-flow diagrams.
 - Use `docs/plugin-flow.md` for plugin realtime/audio callback details.

--- a/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
+++ b/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
@@ -16,8 +16,8 @@ use sync::{ArcAtomicBool, RwLock};
 
 use crate::{
     MidiBpmDetector, MidiBpmDetectorParams, Task,
+    parameter_sync::{GUI_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncRequest},
     plugin_parameters::{apply_duration_param, apply_float_param, apply_int_param, apply_onoff_param},
-    task_executor::UpdateOrigin,
 };
 
 const CONFIG: &str = include_str!("../config/base_config.toml");
@@ -93,26 +93,26 @@ impl BaseConfig {
     pub fn apply_delayed_updates(&mut self) {
         if self
             .delayed_update_static_bpm_detection_config
-            .is_some_and(|instant| instant.elapsed() > Duration::from_millis(200))
+            .is_some_and(|instant| instant.elapsed() > GUI_PARAMETER_SYNC_COALESCING_WINDOW)
         {
             {
                 *self.shared_config.write() = self.config.clone();
             }
 
             self.force_evaluate_bpm_detection.store(true, Ordering::Relaxed);
-            self.async_executor.execute_background(Task::StaticBPMDetectionConfig(UpdateOrigin::Gui));
+            self.async_executor.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncRequest::Gui));
             self.delayed_update_static_bpm_detection_config = None;
             info!("apply static params");
         }
         if self
             .delayed_update_dynamic_bpm_detection_config
-            .is_some_and(|instant| instant.elapsed() > Duration::from_millis(200))
+            .is_some_and(|instant| instant.elapsed() > GUI_PARAMETER_SYNC_COALESCING_WINDOW)
         {
             {
                 *self.shared_config.write() = self.config.clone();
             }
             self.force_evaluate_bpm_detection.store(true, Ordering::Relaxed);
-            self.async_executor.execute_background(Task::DynamicBPMDetectionConfig(UpdateOrigin::Gui));
+            self.async_executor.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Gui));
             self.delayed_update_dynamic_bpm_detection_config = None;
             info!("apply dynamic params");
         }

--- a/crates/midi-bpm-detector-plugin/src/lib.rs
+++ b/crates/midi-bpm-detector-plugin/src/lib.rs
@@ -6,6 +6,7 @@
 
 mod bpm_detector_configuration;
 mod gui;
+mod parameter_sync;
 mod plugin_parameters;
 mod task_executor;
 
@@ -22,7 +23,6 @@ use bpm_detection_core::{
     note_events::NoteOn,
     parameters::{duration_to_sample, sample_to_duration},
 };
-use chrono::Duration;
 use crossbeam::atomic::AtomicCell;
 #[cfg(not(debug_assertions))]
 use mimalloc::MiMalloc;
@@ -34,8 +34,9 @@ use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, ArcAtomicOptionUsize, RwLoc
 use crate::{
     bpm_detector_configuration::PluginConfig,
     gui::GuiEditor,
+    parameter_sync::{HOST_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncRequest},
     plugin_parameters::MidiBpmDetectorParams,
-    task_executor::{Event, Task, UpdateOrigin},
+    task_executor::{Event, Task},
 };
 
 fn midi_note_on_from_message(event: &wmidi::MidiMessage<'_>) -> Option<NoteOn> {
@@ -267,12 +268,12 @@ impl Plugin for MidiBpmDetector {
             return if self.params.editor_state.is_open() { ProcessStatus::KeepAlive } else { ProcessStatus::Normal };
         };
         let current_sample = self.current_sample.load(Ordering::Relaxed);
-        let delay_by = duration_to_sample(sample_rate, Duration::milliseconds(50));
+        let delay_by = duration_to_sample(sample_rate, HOST_PARAMETER_SYNC_COALESCING_WINDOW);
         Self::execute_at_delay(current_sample, delay_by, &self.static_bpm_detection_config_changed_at, || {
-            context.execute_background(Task::StaticBPMDetectionConfig(UpdateOrigin::Daw));
+            context.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncRequest::Host));
         });
         Self::execute_at_delay(current_sample, delay_by, &self.dynamic_bpm_detection_config_changed_at, || {
-            context.execute_background(Task::DynamicBPMDetectionConfig(UpdateOrigin::Daw));
+            context.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Host));
         });
         self.receive_notes_at_sample_rate(context, sample_rate);
         self.current_sample.fetch_add(buffer.samples(), Ordering::Relaxed);

--- a/crates/midi-bpm-detector-plugin/src/parameter_sync.rs
+++ b/crates/midi-bpm-detector-plugin/src/parameter_sync.rs
@@ -1,0 +1,12 @@
+use std::time::Duration as StdDuration;
+
+use chrono::Duration;
+
+pub const HOST_PARAMETER_SYNC_COALESCING_WINDOW: Duration = Duration::milliseconds(50);
+pub const GUI_PARAMETER_SYNC_COALESCING_WINDOW: StdDuration = StdDuration::from_millis(200);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParameterSyncRequest {
+    Host,
+    Gui,
+}

--- a/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -17,23 +17,18 @@ use parameter::OnOff;
 use ringbuf::{SharedRb, consumer::Consumer, storage::Array, wrap::frozen::Frozen};
 use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
 
-use crate::{MidiBpmDetectorParams, bpm_detector_configuration::PluginConfig};
+use crate::{MidiBpmDetectorParams, bpm_detector_configuration::PluginConfig, parameter_sync::ParameterSyncRequest};
 
 const TEMPO_CONTROLLER_CONNECT_TIMEOUT: Duration = Duration::from_millis(10);
 const TEMPO_CONTROLLER_WRITE_TIMEOUT: Duration = Duration::from_millis(10);
 const TEMPO_CONTROLLER_PAYLOAD_BYTES: u32 = 4;
 const TEMPO_CONTROLLER_FRAME_BYTES: usize = 8;
 
-#[derive(Eq, PartialEq)]
-pub enum UpdateOrigin {
-    Daw,
-    Gui,
-}
-
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Task {
     ProcessNotes { force_evaluate_bpm_detection: bool },
-    StaticBPMDetectionConfig(UpdateOrigin),
-    DynamicBPMDetectionConfig(UpdateOrigin),
+    StaticBPMDetectionConfig(ParameterSyncRequest),
+    DynamicBPMDetectionConfig(ParameterSyncRequest),
 }
 
 pub enum Event {
@@ -107,9 +102,9 @@ impl TaskExecutor {
                 }
             }
 
-            Task::StaticBPMDetectionConfig(origin) => {
-                match origin {
-                    UpdateOrigin::Daw => {
+            Task::StaticBPMDetectionConfig(sync) => {
+                match sync {
+                    ParameterSyncRequest::Host => {
                         let config = {
                             let mut config = self.config.write();
                             config.static_bpm_detection_config.bpm_center =
@@ -135,7 +130,7 @@ impl TaskExecutor {
                         self.bpm_detection.update_static_config(config);
                         self.execute(Task::ProcessNotes { force_evaluate_bpm_detection: true });
                     }
-                    UpdateOrigin::Gui => {
+                    ParameterSyncRequest::Gui => {
                         let config = self.config.read();
                         let static_bpm_detection_config = &config.static_bpm_detection_config;
                         self.bpm_detection.update_static_config(static_bpm_detection_config.clone());
@@ -144,8 +139,8 @@ impl TaskExecutor {
                     }
                 }
             }
-            Task::DynamicBPMDetectionConfig(origin) => match origin {
-                UpdateOrigin::Daw => {
+            Task::DynamicBPMDetectionConfig(sync) => match sync {
+                ParameterSyncRequest::Host => {
                     {
                         let mut config = self.config.write();
 
@@ -206,7 +201,7 @@ impl TaskExecutor {
                     self.gui_must_update_config.store(true, Ordering::Relaxed);
                     self.execute(Task::ProcessNotes { force_evaluate_bpm_detection: true });
                 }
-                UpdateOrigin::Gui => {
+                ParameterSyncRequest::Gui => {
                     let config = self.config.read();
                     self.dynamic_bpm_detection_config = config.dynamic_bpm_detection_config.clone();
                 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,13 +327,16 @@ Both surfaces need to stay in sync, but blindly reflecting every update in both 
 the DAW updates the plugin, the GUI mirrors the change, the GUI writes the value back through the plugin setter, and the
 host treats that as another user edit.
 
-The current plugin code handles this by tagging config tasks with `UpdateOrigin::Daw` or `UpdateOrigin::Gui`. The
-origin decides which side is considered authoritative for that update and whether the other side must refresh its local
-config. The detailed host-origin and GUI-origin flows live in [runtime lifecycle](runtime-lifecycle.md).
+The current plugin code handles this by tagging config tasks with `ParameterSyncRequest::Host` or
+`ParameterSyncRequest::Gui`. The origin decides which side is considered authoritative for that update and whether the
+other side must refresh its local config. The detailed host-origin and GUI-origin flows live in
+[runtime lifecycle](runtime-lifecycle.md).
 
-This area is a likely refactor target. The desired end state is a small, explicit parameter-sync protocol that documents
-which surface owns an update, which side must refresh, and when BPM recomputation is required. That protocol should make
-feedback-loop prevention obvious instead of depending on scattered flags and timing behavior.
+The desired cleanup is intentionally small: keep the worker task origin explicit and keep the fixed timing constants named.
+The docs spell out which surface owns an update, which side must refresh, and when BPM recomputation is required. Do not
+model a possible third origin or shared policy layer before production code needs it. This should not become a generic
+parameter framework: origin-specific call sites should keep direct facts direct, such as fixed coalescing windows and
+unconditional forced recompute, instead of asking a shared policy object questions whose answer cannot vary there.
 
 ## Open Architecture Questions
 
@@ -347,7 +350,8 @@ These points are worth re-checking when changing ownership, communication, or ru
 - Plugin mode is the production target and drives the realtime constraints. Desktop and WASM preserve the same model but
   can use less restrictive runtime mechanisms.
 - Plugin parameter synchronization is intentionally bidirectional, but the current implementation may still contain
-  workaround-shaped code from avoiding DAW/GUI feedback loops. Review this before documenting it as final design.
+  workaround-shaped code from avoiding DAW/GUI feedback loops. Review this before documenting it as final design, and
+  avoid adding optional-looking policy paths for states that are not actually possible at a given boundary.
 - Prefer typed peer boundaries wired at bootstrap over adding more cases to a runtime-wide event bus. If a bootstrap
   section starts looking like a hidden orchestrator, split the peer protocol instead of centralizing more behavior.
 - [Runtime lifecycle](runtime-lifecycle.md) is the authoritative data-flow/thread-boundary diagram. More detailed

--- a/docs/runtime-lifecycle.md
+++ b/docs/runtime-lifecycle.md
@@ -208,8 +208,8 @@ sequenceDiagram
     Host->>Params: set static/dynamic/gui parameter
     Params->>Marker: mark_changed_at_if_idle(current_sample)
     Process->>Marker: after 50 ms worth of samples
-    Process->>Exec: Task::StaticBPMDetectionConfig(UpdateOrigin::Daw)
-    Process->>Exec: Task::DynamicBPMDetectionConfig(UpdateOrigin::Daw)
+    Process->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncRequest::Host)
+    Process->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Host)
     Exec->>Config: copy authoritative values from host params
     Exec->>Gui: gui_must_update_config = true
     Exec->>Model: update_static_config or dynamic config snapshot
@@ -217,8 +217,8 @@ sequenceDiagram
     Gui->>Config: reload config on next editor update
 ```
 
-The host parameter surface is authoritative for `UpdateOrigin::Daw`. The GUI refreshes from shared config instead of
-echoing the same edit back to the host as a new user action.
+The host parameter surface is authoritative for host-origin parameter sync. The GUI refreshes from shared config instead
+of echoing the same edit back to the host as a new user action.
 
 ## Plugin Parameter Changes From The GUI
 
@@ -235,16 +235,29 @@ sequenceDiagram
     Live->>Setter: begin/set/end matching host parameter
     Live->>Live: delay static or dynamic change for 200 ms
     Live->>Config: write edited PluginConfig after delay
-    Live->>Exec: Task::StaticBPMDetectionConfig(UpdateOrigin::Gui)
-    Live->>Exec: Task::DynamicBPMDetectionConfig(UpdateOrigin::Gui)
+    Live->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncRequest::Gui)
+    Live->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Gui)
     Exec->>Config: read GUI-authored config
     Exec->>Model: apply static config or dynamic snapshot
     Exec->>Model: recompute on forced ProcessNotes
 ```
 
 The GUI-origin path intentionally writes host parameters through `ParamSetter`, because the DAW surface must reflect the
-editor change. The `UpdateOrigin::Gui` tasks then let the background BPM model consume the already-shared config without
-treating the host callback as the source of truth.
+editor change. The GUI-origin parameter sync tasks then let the background BPM model consume the already-shared config
+without treating the host callback as the source of truth.
+
+The plugin code names the origin with `ParameterSyncRequest::Host` or `ParameterSyncRequest::Gui`; the consequences are
+fixed:
+
+| Origin | Authoritative surface | Coalescing window | GUI refresh | Host refresh | BPM recompute |
+| --- | --- | --- | --- | --- | --- |
+| Host/DAW | host parameters | 50 ms on the host sample clock | reload from shared config | already current | immediate worker task |
+| GUI | shared GUI-authored config | 200 ms on the editor wall clock | already current | `ParamSetter` write-through before the worker task | next realtime `process()` block |
+
+This table documents behavior, not optional capabilities. It is useful because the worker receives both host-origin and
+GUI-origin config tasks. At origin-specific call sites, keep known facts direct: the host path uses the host coalescing
+window, the GUI path uses the GUI coalescing window and always marks BPM detection for re-evaluation before queueing a
+GUI-origin task.
 
 ## Plugin GUI Open And Close
 
@@ -389,7 +402,13 @@ channels. It is useful for demos and model/UI iteration, not the production cons
 
 - **Plugin parameter synchronization is functional but distributed.** The lifecycle crosses host callbacks,
   `DeferredConfigUpdate`, `process()`, `TaskExecutor`, `GuiEditor`, `BaseConfig`, `LiveConfig`, `ParamSetter`, and shared
-  config flags. A future refactor should introduce a small named parameter-sync protocol before changing behavior.
+  config flags. The current cleanup target is narrow: name the worker task origin and timing constants, then stop. Future
+  steps should keep behavior changes separate from protocol naming, and should not add policy enums, mapping methods,
+  optional-looking branches, or future origins before production code needs them.
+- **Parameter definitions and GUI parameter construction are duplicated across runtime modes.** The shared GUI, plugin
+  host parameters, desktop config, and WASM/demo paths each need their own representation or accessor layer. The current
+  GUI parameter-list construction also carries history from earlier boilerplate reduction work. Review this separately
+  from parameter synchronization so the sync protocol does not become a generic parameter framework by accident.
 - **Static and dynamic config flows share concepts but use different timing mechanisms.** Plugin host-origin changes use
   sample-based delay from the realtime callback, plugin GUI-origin changes use wall-clock delay in the editor, desktop
   worker changes use the worker debounce schedule, and WASM uses async delayed queue items. That may be fine, but it


### PR DESCRIPTION
## Summary
- replace plugin config task origin with ParameterSyncRequest::Host/Gui
- name host and GUI parameter-sync coalescing windows
- document parameter-sync boundaries and add guardrails against false reuse

## Verification
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo test --locked -p midi-bpm-detector-plugin
- cargo clippy --locked -p midi-bpm-detector-plugin -- -D warnings