### PR TITLE
Rename parameter sync request origin

### DIFF
--- a/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
+++ b/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
@@ -16,7 +16,7 @@ use sync::{ArcAtomicBool, RwLock};
 
 use crate::{
     MidiBpmDetector, MidiBpmDetectorParams, Task,
-    parameter_sync::{GUI_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncRequest},
+    parameter_sync::{GUI_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncOrigin},
     plugin_parameters::{apply_duration_param, apply_float_param, apply_int_param, apply_onoff_param},
 };
 
@@ -100,7 +100,7 @@ impl BaseConfig {
             }
 
             self.force_evaluate_bpm_detection.store(true, Ordering::Relaxed);
-            self.async_executor.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncRequest::Gui));
+            self.async_executor.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Gui));
             self.delayed_update_static_bpm_detection_config = None;
             info!("apply static params");
         }
@@ -112,7 +112,7 @@ impl BaseConfig {
                 *self.shared_config.write() = self.config.clone();
             }
             self.force_evaluate_bpm_detection.store(true, Ordering::Relaxed);
-            self.async_executor.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Gui));
+            self.async_executor.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Gui));
             self.delayed_update_dynamic_bpm_detection_config = None;
             info!("apply dynamic params");
         }

--- a/crates/midi-bpm-detector-plugin/src/lib.rs
+++ b/crates/midi-bpm-detector-plugin/src/lib.rs
@@ -34,7 +34,7 @@ use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, ArcAtomicOptionUsize, RwLoc
 use crate::{
     bpm_detector_configuration::PluginConfig,
     gui::GuiEditor,
-    parameter_sync::{HOST_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncRequest},
+    parameter_sync::{HOST_PARAMETER_SYNC_COALESCING_WINDOW, ParameterSyncOrigin},
     plugin_parameters::MidiBpmDetectorParams,
     task_executor::{Event, Task},
 };
@@ -270,10 +270,10 @@ impl Plugin for MidiBpmDetector {
         let current_sample = self.current_sample.load(Ordering::Relaxed);
         let delay_by = duration_to_sample(sample_rate, HOST_PARAMETER_SYNC_COALESCING_WINDOW);
         Self::execute_at_delay(current_sample, delay_by, &self.static_bpm_detection_config_changed_at, || {
-            context.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncRequest::Host));
+            context.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Host));
         });
         Self::execute_at_delay(current_sample, delay_by, &self.dynamic_bpm_detection_config_changed_at, || {
-            context.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Host));
+            context.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Host));
         });
         self.receive_notes_at_sample_rate(context, sample_rate);
         self.current_sample.fetch_add(buffer.samples(), Ordering::Relaxed);

--- a/crates/midi-bpm-detector-plugin/src/parameter_sync.rs
+++ b/crates/midi-bpm-detector-plugin/src/parameter_sync.rs
@@ -6,7 +6,7 @@ pub const HOST_PARAMETER_SYNC_COALESCING_WINDOW: Duration = Duration::millisecon
 pub const GUI_PARAMETER_SYNC_COALESCING_WINDOW: StdDuration = StdDuration::from_millis(200);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ParameterSyncRequest {
+pub enum ParameterSyncOrigin {
     Host,
     Gui,
 }

--- a/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -17,7 +17,7 @@ use parameter::OnOff;
 use ringbuf::{SharedRb, consumer::Consumer, storage::Array, wrap::frozen::Frozen};
 use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
 
-use crate::{MidiBpmDetectorParams, bpm_detector_configuration::PluginConfig, parameter_sync::ParameterSyncRequest};
+use crate::{MidiBpmDetectorParams, bpm_detector_configuration::PluginConfig, parameter_sync::ParameterSyncOrigin};
 
 const TEMPO_CONTROLLER_CONNECT_TIMEOUT: Duration = Duration::from_millis(10);
 const TEMPO_CONTROLLER_WRITE_TIMEOUT: Duration = Duration::from_millis(10);
@@ -27,8 +27,8 @@ const TEMPO_CONTROLLER_FRAME_BYTES: usize = 8;
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Task {
     ProcessNotes { force_evaluate_bpm_detection: bool },
-    StaticBPMDetectionConfig(ParameterSyncRequest),
-    DynamicBPMDetectionConfig(ParameterSyncRequest),
+    StaticBPMDetectionConfig(ParameterSyncOrigin),
+    DynamicBPMDetectionConfig(ParameterSyncOrigin),
 }
 
 pub enum Event {
@@ -104,7 +104,7 @@ impl TaskExecutor {
 
             Task::StaticBPMDetectionConfig(sync) => {
                 match sync {
-                    ParameterSyncRequest::Host => {
+                    ParameterSyncOrigin::Host => {
                         let config = {
                             let mut config = self.config.write();
                             config.static_bpm_detection_config.bpm_center =
@@ -130,7 +130,7 @@ impl TaskExecutor {
                         self.bpm_detection.update_static_config(config);
                         self.execute(Task::ProcessNotes { force_evaluate_bpm_detection: true });
                     }
-                    ParameterSyncRequest::Gui => {
+                    ParameterSyncOrigin::Gui => {
                         let config = self.config.read();
                         let static_bpm_detection_config = &config.static_bpm_detection_config;
                         self.bpm_detection.update_static_config(static_bpm_detection_config.clone());
@@ -140,7 +140,7 @@ impl TaskExecutor {
                 }
             }
             Task::DynamicBPMDetectionConfig(sync) => match sync {
-                ParameterSyncRequest::Host => {
+                ParameterSyncOrigin::Host => {
                     {
                         let mut config = self.config.write();
 
@@ -201,7 +201,7 @@ impl TaskExecutor {
                     self.gui_must_update_config.store(true, Ordering::Relaxed);
                     self.execute(Task::ProcessNotes { force_evaluate_bpm_detection: true });
                 }
-                ParameterSyncRequest::Gui => {
+                ParameterSyncOrigin::Gui => {
                     let config = self.config.read();
                     self.dynamic_bpm_detection_config = config.dynamic_bpm_detection_config.clone();
                 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,8 +327,8 @@ Both surfaces need to stay in sync, but blindly reflecting every update in both 
 the DAW updates the plugin, the GUI mirrors the change, the GUI writes the value back through the plugin setter, and the
 host treats that as another user edit.
 
-The current plugin code handles this by tagging config tasks with `ParameterSyncRequest::Host` or
-`ParameterSyncRequest::Gui`. The origin decides which side is considered authoritative for that update and whether the
+The current plugin code handles this by tagging config tasks with `ParameterSyncOrigin::Host` or
+`ParameterSyncOrigin::Gui`. The origin decides which side is considered authoritative for that update and whether the
 other side must refresh its local config. The detailed host-origin and GUI-origin flows live in
 [runtime lifecycle](runtime-lifecycle.md).
 

--- a/docs/runtime-lifecycle.md
+++ b/docs/runtime-lifecycle.md
@@ -208,8 +208,8 @@ sequenceDiagram
     Host->>Params: set static/dynamic/gui parameter
     Params->>Marker: mark_changed_at_if_idle(current_sample)
     Process->>Marker: after 50 ms worth of samples
-    Process->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncRequest::Host)
-    Process->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Host)
+    Process->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Host)
+    Process->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Host)
     Exec->>Config: copy authoritative values from host params
     Exec->>Gui: gui_must_update_config = true
     Exec->>Model: update_static_config or dynamic config snapshot
@@ -235,8 +235,8 @@ sequenceDiagram
     Live->>Setter: begin/set/end matching host parameter
     Live->>Live: delay static or dynamic change for 200 ms
     Live->>Config: write edited PluginConfig after delay
-    Live->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncRequest::Gui)
-    Live->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncRequest::Gui)
+    Live->>Exec: Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Gui)
+    Live->>Exec: Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Gui)
     Exec->>Config: read GUI-authored config
     Exec->>Model: apply static config or dynamic snapshot
     Exec->>Model: recompute on forced ProcessNotes
@@ -246,7 +246,7 @@ The GUI-origin path intentionally writes host parameters through `ParamSetter`, 
 editor change. The GUI-origin parameter sync tasks then let the background BPM model consume the already-shared config
 without treating the host callback as the source of truth.
 
-The plugin code names the origin with `ParameterSyncRequest::Host` or `ParameterSyncRequest::Gui`; the consequences are
+The plugin code names the origin with `ParameterSyncOrigin::Host` or `ParameterSyncOrigin::Gui`; the consequences are
 fixed:
 
 | Origin | Authoritative surface | Coalescing window | GUI refresh | Host refresh | BPM recompute |


### PR DESCRIPTION
## Summary
- Rename ParameterSyncRequest to ParameterSyncOrigin
- Update plugin call sites and lifecycle docs to use the origin name

## Verification
- cargo +nightly fmt --all -- --check
- git diff --check
- cargo test --locked -p midi-bpm-detector-plugin
- cargo clippy --locked -p midi-bpm-detector-plugin -- -D warnings