### PR TITLE
Clarify docs status quo and refactor prompts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,11 +332,9 @@ The current plugin code handles this by tagging config tasks with `ParameterSync
 other side must refresh its local config. The detailed host-origin and GUI-origin flows live in
 [runtime lifecycle](runtime-lifecycle.md).
 
-The desired cleanup is intentionally small: keep the worker task origin explicit and keep the fixed timing constants named.
-The docs spell out which surface owns an update, which side must refresh, and when BPM recomputation is required. Do not
-model a possible third origin or shared policy layer before production code needs it. This should not become a generic
-parameter framework: origin-specific call sites should keep direct facts direct, such as fixed coalescing windows and
-unconditional forced recompute, instead of asking a shared policy object questions whose answer cannot vary there.
+The current boundary is intentionally small: the worker task carries only the update origin, and the fixed timing and
+recompute facts stay direct at the origin-specific call sites. This is not a generic parameter framework. Do not model a
+possible third origin or shared policy layer before production code needs it.
 
 ## Open Architecture Questions
 
@@ -349,9 +347,9 @@ These points are worth re-checking when changing ownership, communication, or ru
   and egui rendering.
 - Plugin mode is the production target and drives the realtime constraints. Desktop and WASM preserve the same model but
   can use less restrictive runtime mechanisms.
-- Plugin parameter synchronization is intentionally bidirectional, but the current implementation may still contain
-  workaround-shaped code from avoiding DAW/GUI feedback loops. Review this before documenting it as final design, and
-  avoid adding optional-looking policy paths for states that are not actually possible at a given boundary.
+- Plugin parameter synchronization is intentionally bidirectional. Before changing it, re-check the lifecycle docs and
+  preserve the current distinction between host-origin and GUI-origin updates. Avoid adding optional-looking policy paths
+  for states that are not actually possible at a given boundary.
 - Prefer typed peer boundaries wired at bootstrap over adding more cases to a runtime-wide event bus. If a bootstrap
   section starts looking like a hidden orchestrator, split the peer protocol instead of centralizing more behavior.
 - [Runtime lifecycle](runtime-lifecycle.md) is the authoritative data-flow/thread-boundary diagram. More detailed

--- a/docs/native-midi-flow.md
+++ b/docs/native-midi-flow.md
@@ -145,10 +145,8 @@ This keeps clock ticks, play/stop, and optional tempo SysEx serialized through o
 while draining output commands: when several tempo values are queued, only the newest value is emitted.
 
 MIDI clock enablement is currently a shared atomic flag read by the output thread. That avoids blocking a GUI caller on
-the output owner, but it also means the output thread uses a short idle timeout while the clock is disabled. A better
-future shape is likely an event plus state pair: writers update cheap shared state, then wake the output owner so it can
-react without polling. Any change here should keep the clock tick path owned by one thread and avoid introducing native
-MIDI dependencies into `gui`.
+the output owner, but it also means the output thread uses a short idle timeout while the clock is disabled. The current
+design keeps the clock tick path owned by one thread and avoids introducing native MIDI dependencies into `gui`.
 
 ## Config Timing
 
@@ -171,3 +169,6 @@ These names and boundaries are current working vocabulary, not final doctrine:
   event enum again, treat that as a refactor candidate rather than a design rule.
 - The native MIDI clock path is desktop/experimental support. The plugin production path uses a controller bridge
   instead of acting as a MIDI clock provider.
+- If the output thread's disabled-clock polling becomes a real problem, review an event-plus-state shape: writers update
+  cheap shared state, then wake the output owner so it can react without polling. Keep that as an output-thread ownership
+  refactor, not a reason for `gui` to learn native MIDI details.

--- a/docs/runtime-lifecycle.md
+++ b/docs/runtime-lifecycle.md
@@ -398,13 +398,17 @@ sequenceDiagram
 WASM follows the same conceptual pipeline, but browser constraints replace native threads with async tasks and bounded
 channels. It is useful for demos and model/UI iteration, not the production constraint.
 
-## Current Refactor Signals
+## Refactor Review Prompts
+
+This section is not part of the implemented runtime contract. It records places to inspect when planning future cleanup,
+and each note includes a stop condition so it does not become an accidental architecture plan.
 
 - **Plugin parameter synchronization is functional but distributed.** The lifecycle crosses host callbacks,
   `DeferredConfigUpdate`, `process()`, `TaskExecutor`, `GuiEditor`, `BaseConfig`, `LiveConfig`, `ParamSetter`, and shared
-  config flags. The current cleanup target is narrow: name the worker task origin and timing constants, then stop. Future
-  steps should keep behavior changes separate from protocol naming, and should not add policy enums, mapping methods,
-  optional-looking branches, or future origins before production code needs them.
+  config flags. The current cleanup target has been completed: the worker task origin and timing constants are named.
+  Stop there unless production code gains another real consumer of shared parameter-sync behavior. Future steps should
+  keep behavior changes separate from protocol naming, and should not add policy enums, mapping methods, optional-looking
+  branches, or future origins before production code needs them.
 - **Parameter definitions and GUI parameter construction are duplicated across runtime modes.** The shared GUI, plugin
   host parameters, desktop config, and WASM/demo paths each need their own representation or accessor layer. The current
   GUI parameter-list construction also carries history from earlier boilerplate reduction work. Review this separately


### PR DESCRIPTION
## Summary
- Keep plugin parameter synchronization wording in architecture.md focused on current behavior
- Rename runtime-lifecycle refactor notes to review prompts with explicit stop conditions
- Move the native MIDI clock future idea out of the current output ownership description

## Verification
- git diff --check
- rg scan for removed ambiguous phrases