### PR TITLE
Avoid duplicate plugin release build in native CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         run: cargo clippy --locked --target ${{ matrix.target }} --workspace --exclude wasm --all-targets -- -D warnings
 
       - name: Build native crates
-        run: cargo build --locked --release --target ${{ matrix.target }} -p desktop -p midi-bpm-detector-plugin -p midi-reset
+        run: cargo build --locked --release --target ${{ matrix.target }} -p desktop -p midi-reset
 
       - name: Bundle plugin
         run: cargo run --locked --package xtask --release -- bundle midi-bpm-detector-plugin --release --target ${{ matrix.target }} --locked


### PR DESCRIPTION
## Summary
- remove midi-bpm-detector-plugin from the explicit native release build step
- leave plugin compilation and CLAP/VST3 bundle creation owned by the existing Bundle plugin step

## Verification
- cargo build --locked --release --target aarch64-apple-darwin -p desktop -p midi-reset
- cargo run --locked --package xtask --release -- bundle midi-bpm-detector-plugin --release --target aarch64-apple-darwin --locked
- git diff --check