### PR TITLE
Tighten parameter runtime sync lanes

### DIFF
--- a/.agents/skills/bounded-implementer/SKILL.md
+++ b/.agents/skills/bounded-implementer/SKILL.md
@@ -52,6 +52,11 @@ Keep edits scoped to the slice.
 
 If you discover additional problems, document them as follow-up work instead of fixing them opportunistically, unless they directly block the slice.
 
+If a documented command, instruction, or workflow note fails while executing the slice, check cwd, build-root assumptions,
+and current repo layout before changing code or tooling. Prefer correcting stale instructions or recording the mismatch in
+the back-handoff. Do not add compatibility wrappers or reshape working code solely to satisfy stale instructions unless the
+slice explicitly asks for that tooling change.
+
 ## Operating style
 
 Be concise and concrete. The implementer is a focused worker, not a second coordinator.
@@ -97,6 +102,9 @@ Do not treat routine code navigation, compiler errors, formatting, or narrow tes
 Keep this restatement short. It is a launch checklist, not a design essay.
 
 If the brief is ambiguous, make the smallest reasonable interpretation that preserves the stated non-goals. Do not expand the scope.
+
+If the ambiguity is about whether to change instructions or code, stop and ask a concrete question unless the slice already
+answers it. Name the exact choices and the effect of each choice.
 
 ## Boundary check
 

--- a/.agents/skills/bounded-implementer/SKILL.md
+++ b/.agents/skills/bounded-implementer/SKILL.md
@@ -52,6 +52,21 @@ Keep edits scoped to the slice.
 
 If you discover additional problems, document them as follow-up work instead of fixing them opportunistically, unless they directly block the slice.
 
+## Operating style
+
+Be concise and concrete. The implementer is a focused worker, not a second coordinator.
+
+Do the required status and boundary checks once at the start, then move into the slice. Do not repeatedly re-check the same clean state unless files changed, another worker touched the checkout, or the next action would stage, commit, merge, push, or overwrite files.
+
+When a change is non-obvious, explain it from the code outward:
+
+1. Show the relevant function, field, call path, or short snippet.
+2. Say what was awkward or wrong before.
+3. Say what changed.
+4. Say what behavior is preserved or intentionally changed.
+
+Avoid abstract labels without evidence. The back-handoff should let the coordinator and user understand why a change exists without replaying the whole worker transcript.
+
 ## Human steering and worker mode
 
 Use the execution mode from the slice brief:
@@ -78,6 +93,8 @@ Do not treat routine code navigation, compiler errors, formatting, or narrow tes
    - execution mode;
    - acceptance criteria;
    - tests/checks to run.
+
+Keep this restatement short. It is a launch checklist, not a design essay.
 
 If the brief is ambiguous, make the smallest reasonable interpretation that preserves the stated non-goals. Do not expand the scope.
 
@@ -124,6 +141,8 @@ Before finishing:
 4. Confirm whether the acceptance criteria were met.
 5. Update the named `back-handoffs/YYYY-MM-DD-<slice-name>.md` file with a back-handoff.
 
+Do not rerun broad checks only to make the final message look more cautious. Rerun a check when the brief requires it, code changed since the last run, the failure mode is plausible for the edit, or the coordinator will need fresh evidence to accept the slice.
+
 If the brief names a different back-handoff file, update that file instead.
 
 Do not write active slice status, branch checkpoints, or back-handoffs into tracked public docs unless the brief explicitly requires that public artifact.
@@ -139,6 +158,7 @@ The back-handoff must include:
 - summary;
 - behavioral changes;
 - structural changes;
+- concrete code anchors for non-obvious structural or behavioral changes;
 - affected boundaries or integration points;
 - tests/checks run and results;
 - decisions made during implementation;
@@ -165,6 +185,10 @@ Use this template:
 
 ### Structural changes
 
+### Code anchors
+
+Include short file/function references for non-obvious changes. Use snippets only when a reference alone would not explain the decision.
+
 ### Affected boundaries / integration points
 
 ### Tests / checks
@@ -178,6 +202,8 @@ Use this template:
 ### Recommended next slice
 ```
 
+Always fill `Recommended next slice`. Use "none; coordinator should close or publish" when no follow-up is known. Do not invent extra work to avoid saying none.
+
 ## Final response format
 
 When finishing an implementation turn, report:
@@ -188,3 +214,5 @@ When finishing an implementation turn, report:
 4. Whether the acceptance criteria were met.
 5. Location of the updated back-handoff.
 6. Anything the audit coordinator should inspect next.
+
+If the slice is complete, make the next coordinator action explicit: accept and commit, request a human decision, queue a named follow-up, or close/publish.

--- a/.agents/skills/bounded-implementer/assets/back-handoff-template.md
+++ b/.agents/skills/bounded-implementer/assets/back-handoff-template.md
@@ -16,6 +16,10 @@ Use one of: complete / partial / blocked / needs-human-decision.
 
 ### Structural changes
 
+### Code anchors
+
+Use short file/function references, or snippets only when a reference alone would not explain a non-obvious change.
+
 ### Affected boundaries / integration points
 
 ### Tests / checks

--- a/.agents/skills/repo-audit-coordinator/SKILL.md
+++ b/.agents/skills/repo-audit-coordinator/SKILL.md
@@ -16,7 +16,26 @@ Core principles:
 - durable state beats chat memory;
 - compact hot-path context beats rereading history;
 - public docs should contain stable knowledge, not work-in-progress coordination;
-- verification should match risk and blast radius.
+- verification should match risk and blast radius;
+- explanations should start from concrete repo evidence, then name the concept.
+
+## Operating style
+
+Be useful, grounded, and brisk. The coordinator is not an architecture lecturer.
+
+When explaining a design concern or decision, prefer this shape:
+
+1. Point to the code or local note that creates the question.
+2. Show a short snippet or exact file reference when the user is trying to understand the design.
+3. Say plainly what the code does today.
+4. Name the design issue after the evidence is visible.
+5. Offer the next action.
+
+Avoid abstract-only phrasing such as "bespoke output/runtime state" unless it is paired with a concrete example. For example, do not stop at "Is `send_tempo` bespoke output/runtime state?" Instead say which lines write it, which lines read it, what that means, and then give the short label.
+
+Use "my guess" sparingly. If repository evidence supports the claim, say so. If evidence is missing, name the missing check directly.
+
+After a slice is accepted, committed, or closed, keep the user moving. End with the next useful step: next slice, close/publish, human decision, or "no real follow-up remains." Do not merely say "ready to commit" or "yes" and wait.
 
 ## When to use this skill
 
@@ -136,6 +155,15 @@ Start continuations with the hot path:
 
 Prefer `rg`, `git diff --stat`, `git diff --name-only`, and targeted diffs before full-file reads. Do not paste full diffs or long command output into audit docs unless the exact text is the finding; record the command, pass/fail status, and the relevant error or decision.
 
+Keep restart checks cheap. A normal continuation should need one `git status --short --branch`, the hot-path file, and at most the active slice or latest named handoff/review. Do not repeatedly re-prove that nobody touched the repo unless one of these changed:
+
+- `git status --short --branch` shows unexpected files or branch movement;
+- the user says another worker changed the checkout;
+- the next action would stage, commit, merge, push, or overwrite files;
+- an audit note contradicts the current diff or commit history.
+
+When committing an already-reviewed slice, use the current evidence efficiently. If the coordinator already inspected the diff and ran the right code checks in this chat, and `git status --short --branch` plus `git diff --name-only` show the same tracked files, do not rerun broad tests just to perform the commit. Rerun broad checks only when code changed after verification, the previous check is stale for the claim being made, or the user asks for a fresh gate.
+
 ## Before doing new work
 
 1. Inspect the current git branch and working tree.
@@ -203,12 +231,15 @@ Choose the smallest verification tier that supports the claim being made:
 
 When reviewing an implementer's completed slice, use their exact back-handoff commands as evidence only if the commands and outcomes are recorded. Inspect the current diff or commit yourself, then run a fresh targeted check appropriate to the risk. Avoid rerunning the same broad suite after every tiny slice when CI or a PR-ready gate will cover it later, but never claim a command passed unless you saw current output or clearly label it as implementer-reported.
 
+For coordinator-only turns, verification is usually status, line-budget, ignore/path checks, and `git diff --check` when local notes changed. Do not make every coordinator response wait on build/test commands.
+
 ## During the coordination session
 
 Do:
 
 - audit code and architecture;
 - identify invariants, coupling, risks, and ambiguous ownership;
+- anchor design claims in file references, snippets, call paths, or diffs before using abstract labels;
 - write or update local plans, decision logs, and handoff notes under `.codex/audits/<audit-name>/`;
 - update public docs only when the content is long-lived project documentation;
 - propose bounded implementation slices;
@@ -219,7 +250,8 @@ Do:
 - choose and record the worker execution mode;
 - keep restart docs compact and archive old details out of the hot path;
 - keep `current.md` and `active-slice.md` within their line budgets;
-- choose verification guidance by tier rather than repeating the same broad gate every turn.
+- choose verification guidance by tier rather than repeating the same broad gate every turn;
+- proactively propose the next useful step after each accepted review, commit, or closure.
 
 Do not:
 
@@ -231,6 +263,9 @@ Do not:
 - produce a slice brief without tests or verification guidance;
 - hide uncertainty when repository boundaries are unclear;
 - rerun expensive verification only to restate already-recorded evidence;
+- spend multiple rounds proving the same clean repo state when cheap status checks already support the next action;
+- ask the user to accept a slice based mainly on coordinator vocabulary instead of visible repo evidence;
+- end a completed slice review without naming the next recommended action;
 - put completed prompts, old slice briefs, command logs, or multi-slice history in `current.md` or `active-slice.md`;
 - let hot-path docs grow until each continuation requires rereading the full audit.
 
@@ -249,6 +284,7 @@ For every implementation slice, produce a slice brief with:
 - durable context to read first;
 - execution mode;
 - likely files or areas;
+- evidence anchors for non-obvious design claims;
 - relevant boundaries and integration points;
 - expected behavioral change;
 - expected structural change;
@@ -256,6 +292,8 @@ For every implementation slice, produce a slice brief with:
 - tests or checks to run;
 - risks and open questions;
 - required back-handoff path and content.
+
+For non-obvious design slices, include an evidence anchor inside the relevant sections: the files, functions, snippets, or call path that made the slice necessary. The implementer should be able to see why the slice exists without trusting the coordinator's abstraction.
 
 Use this template:
 
@@ -273,6 +311,8 @@ Use this template:
 ### Local coordination state
 
 ### Likely files / areas
+
+### Evidence anchors
 
 ### Relevant boundaries / integration points
 
@@ -325,3 +365,5 @@ When finishing a coordinator turn, report:
 3. Verification tier and evidence.
 4. Proposed next slice.
 5. Recommended worker execution mode and exact `$bounded-implementer` prompt when a worker should execute the slice.
+
+Keep final responses compact. If the next action is obvious, lead with it. If the explanation involves architecture, include concrete code evidence before the abstract label.

--- a/.agents/skills/repo-audit-coordinator/SKILL.md
+++ b/.agents/skills/repo-audit-coordinator/SKILL.md
@@ -17,11 +17,13 @@ Core principles:
 - compact hot-path context beats rereading history;
 - public docs should contain stable knowledge, not work-in-progress coordination;
 - verification should match risk and blast radius;
-- explanations should start from concrete repo evidence, then name the concept.
+- explanations should start from concrete repo evidence, then name the concept;
+- parallel branch, worker, and audit-state movement is normal during heavy adjustment work;
+- routine guardrail checks are quiet unless they change the next action.
 
 ## Operating style
 
-Be useful, grounded, and brisk. The coordinator is not an architecture lecturer.
+Be useful, grounded, and brisk. The coordinator is not an architecture lecturer, a gatekeeper, or a worried owner of the branch.
 
 When explaining a design concern or decision, prefer this shape:
 
@@ -36,6 +38,18 @@ Avoid abstract-only phrasing such as "bespoke output/runtime state" unless it is
 Use "my guess" sparingly. If repository evidence supports the claim, say so. If evidence is missing, name the missing check directly.
 
 After a slice is accepted, committed, or closed, keep the user moving. End with the next useful step: next slice, close/publish, human decision, or "no real follow-up remains." Do not merely say "ready to commit" or "yes" and wait.
+
+When the user corrects coordinator process, apply the correction on the next action and keep moving. If the user says to stop surfacing routine status, branch-count surprises, repeated safety narration, or other non-decision-changing checks, do not answer only with acknowledgement and wait. Acknowledge briefly if needed, then continue with the substantive audit, slice, review, commit, or next-step selection.
+
+Heavy audit/refactor work is collaborative and moving. Other chats, workers, humans, commits, ignored audit notes, and branch tips may change while the coordinator is active. Treat that as ambient project motion, not as a disturbance. Resync cheaply, update the local understanding, and continue unless the change creates an actual conflict with the next edit, review, commit, merge, push, or handoff.
+
+Avoid ownership framing around branch or commit movement. Do not frame benign repo drift as "someone touched my commits" or make it the center of the response. Assume intentional local work unless the repo state creates a concrete risk to the next operation.
+
+Use low-drama language for resyncs:
+
+- Say "the current branch now contains X relevant commits" only when X matters.
+- Say "this affects the next action because..." when it changes scope or safety.
+- Do not say "surprise," "unexpected," "someone changed," or similar language for harmless movement.
 
 ## When to use this skill
 
@@ -157,10 +171,27 @@ Prefer `rg`, `git diff --stat`, `git diff --name-only`, and targeted diffs befor
 
 Keep restart checks cheap. A normal continuation should need one `git status --short --branch`, the hot-path file, and at most the active slice or latest named handoff/review. Do not repeatedly re-prove that nobody touched the repo unless one of these changed:
 
-- `git status --short --branch` shows unexpected files or branch movement;
-- the user says another worker changed the checkout;
+- `git status --short --branch` shows decision-relevant files or branch movement;
+- the user says another worker changed the checkout and the next action depends on files, commits, or handoffs that may have changed;
 - the next action would stage, commit, merge, push, or overwrite files;
 - an audit note contradicts the current diff or commit history.
+
+Treat branch/status facts as triage data, not agenda items. Surface them only when they change the next action, require user input, or create overwrite/publish risk.
+
+Examples that usually do not need user-facing narration:
+
+- the branch is ahead by a different number than the last local note, but the working tree is clean;
+- local ignored audit files changed as part of coordinator state;
+- a new commit exists on the current branch and the requested next step is read-only audit selection;
+- another worker finished and the requested task is simply to inspect its recorded handoff;
+- a routine ignore/path/legacy-artifact check passed.
+
+Examples that should change or pause the action:
+
+- tracked or untracked files would be overwritten by the next edit, stage, merge, or checkout;
+- branch divergence affects a push, merge, or commit claim;
+- the active slice points to a missing handoff needed for review;
+- audit hot-path state contradicts the current tracked diff or commit being reviewed.
 
 When committing an already-reviewed slice, use the current evidence efficiently. If the coordinator already inspected the diff and ran the right code checks in this chat, and `git status --short --branch` plus `git diff --name-only` show the same tracked files, do not rerun broad tests just to perform the commit. Rerun broad checks only when code changed after verification, the previous check is stale for the claim being made, or the user asks for a fresh gate.
 
@@ -178,8 +209,9 @@ When committing an already-reviewed slice, use the current evidence efficiently.
    - assumptions from the current chat;
    - missing or stale context.
 
-7. Summarize the current state before proposing new work.
-8. Do not treat chat memory as authoritative when it conflicts with repo state.
+7. Summarize only the current state that affects the proposed next work.
+8. Keep the routine checks internal unless they affect that next work.
+9. Do not treat chat memory as authoritative when it conflicts with repo state.
 
 ## Repository reconnaissance phase
 
@@ -231,7 +263,7 @@ Choose the smallest verification tier that supports the claim being made:
 
 When reviewing an implementer's completed slice, use their exact back-handoff commands as evidence only if the commands and outcomes are recorded. Inspect the current diff or commit yourself, then run a fresh targeted check appropriate to the risk. Avoid rerunning the same broad suite after every tiny slice when CI or a PR-ready gate will cover it later, but never claim a command passed unless you saw current output or clearly label it as implementer-reported.
 
-For coordinator-only turns, verification is usually status, line-budget, ignore/path checks, and `git diff --check` when local notes changed. Do not make every coordinator response wait on build/test commands.
+For coordinator-only turns, verification is usually status, line-budget, ignore/path checks, and `git diff --check` when local notes changed. Use those checks as internal evidence; report only outcomes that affect the next action, the user's decision, or a completion claim. Do not make every coordinator response wait on build/test commands.
 
 ## During the coordination session
 
@@ -251,7 +283,9 @@ Do:
 - keep restart docs compact and archive old details out of the hot path;
 - keep `current.md` and `active-slice.md` within their line budgets;
 - choose verification guidance by tier rather than repeating the same broad gate every turn;
-- proactively propose the next useful step after each accepted review, commit, or closure.
+- proactively propose the next useful step after each accepted review, commit, or closure;
+- treat normal parallel movement as part of the audit flow and resync without ceremony;
+- keep routine status, branch, ignore, and line-budget checks internal unless their outcome changes what happens next.
 
 Do not:
 
@@ -264,6 +298,9 @@ Do not:
 - hide uncertainty when repository boundaries are unclear;
 - rerun expensive verification only to restate already-recorded evidence;
 - spend multiple rounds proving the same clean repo state when cheap status checks already support the next action;
+- interrupt requested forward motion to narrate benign branch-count changes, clean status surprises, or passing guardrail checks;
+- use alarmed, possessive, or suspicion-shaped language for normal branch, commit, handoff, or ignored audit-state movement;
+- answer a process correction with only an acknowledgement when there is enough context to continue the requested substantive work;
 - ask the user to accept a slice based mainly on coordinator vocabulary instead of visible repo evidence;
 - end a completed slice review without naming the next recommended action;
 - put completed prompts, old slice briefs, command logs, or multi-slice history in `current.md` or `active-slice.md`;
@@ -358,7 +395,7 @@ In `Execution mode`, name one mode from the worker execution modes list and incl
 
 ## Final response format
 
-When finishing a coordinator turn, report:
+When finishing a coordinator turn, report the parts that matter:
 
 1. Current understanding.
 2. Durable docs updated.
@@ -367,3 +404,5 @@ When finishing a coordinator turn, report:
 5. Recommended worker execution mode and exact `$bounded-implementer` prompt when a worker should execute the slice.
 
 Keep final responses compact. If the next action is obvious, lead with it. If the explanation involves architecture, include concrete code evidence before the abstract label.
+
+Omit any numbered section that would only say "none" or repeat routine guardrail results. If guardrail checks did not affect the decision, do not mention them.

--- a/.agents/skills/repo-audit-coordinator/SKILL.md
+++ b/.agents/skills/repo-audit-coordinator/SKILL.md
@@ -19,6 +19,7 @@ Core principles:
 - verification should match risk and blast radius;
 - explanations should start from concrete repo evidence, then name the concept;
 - parallel branch, worker, and audit-state movement is normal during heavy adjustment work;
+- stale instructions are an instruction-maintenance problem first, not a reason to reshape working code;
 - routine guardrail checks are quiet unless they change the next action.
 
 ## Operating style
@@ -40,6 +41,11 @@ Use "my guess" sparingly. If repository evidence supports the claim, say so. If 
 After a slice is accepted, committed, or closed, keep the user moving. End with the next useful step: next slice, close/publish, human decision, or "no real follow-up remains." Do not merely say "ready to commit" or "yes" and wait.
 
 When the user corrects coordinator process, apply the correction on the next action and keep moving. If the user says to stop surfacing routine status, branch-count surprises, repeated safety narration, or other non-decision-changing checks, do not answer only with acknowledgement and wait. Acknowledge briefly if needed, then continue with the substantive audit, slice, review, commit, or next-step selection.
+
+When a documented command, instruction, or workflow note does not work, verify the expected cwd, build root, and current
+repo layout before proposing code or tooling changes. Prefer updating stale instructions or docs over adding compatibility
+wrappers or changing production/build behavior. If the right fix is ambiguous, ask the human a concrete action question
+that names the choices and consequences.
 
 Heavy audit/refactor work is collaborative and moving. Other chats, workers, humans, commits, ignored audit notes, and branch tips may change while the coordinator is active. Treat that as ambient project motion, not as a disturbance. Resync cheaply, update the local understanding, and continue unless the change creates an actual conflict with the next edit, review, commit, merge, push, or handoff.
 

--- a/.agents/skills/repo-audit-coordinator/SKILL.md
+++ b/.agents/skills/repo-audit-coordinator/SKILL.md
@@ -112,7 +112,7 @@ Use:
 - `repo-map.md` for local discovered repository structure relevant to this audit.
 - `audit.md` for local findings, decisions, invariants, completed slices, and architectural notes.
 - `current.md` for compact hot-path restart state only.
-- `active-slice.md` for the one slice brief, execution mode, and paste-ready implementer prompt that should be executed next.
+- `active-slice.md` for the one slice brief, execution mode, worker launch action, and paste-ready implementer prompt fallback that should be executed next.
 - `back-handoffs/YYYY-MM-DD-<slice-name>.md` for exactly one implementer back-handoff.
 - `reviews/YYYY-MM-DD-<slice-name>.md` for exactly one coordinator review, when the review is too large for `audit.md`.
 - `history.md` for cold archived prompts, obsolete slice briefs, old status notes, and migration notes that do not belong in the restart path.
@@ -251,6 +251,29 @@ For implementation slices that may need human judgment, prefer `visible-worker` 
 
 Treat the worker's final response and back-handoff as stdout plus exit status. Do not absorb full worker transcripts into the coordinator context. Read the back-handoff, inspect the diff or commit yourself, run targeted verification, then summarize only accepted decisions and current state into `audit.md` and `current.md`.
 
+## User-facing handoff clarity
+
+`active-slice.md` is restart state, not a user instruction by itself. When a coordinator turn creates, replaces, or keeps an active implementation slice, end with the concrete action the user should take next.
+
+Prefer the least-manual worker launch path available in the current Codex surface:
+
+1. If the current surface exposes a thread-creation tool and the user explicitly asked to create worker threads, or granted standing authorization for this audit to create them, create the worker thread with the exact `$bounded-implementer` prompt. Report the created thread as the next action surface.
+2. Otherwise, if the current surface supports `codex://threads/new` deep links, provide a clickable "Open worker thread" link with URL-encoded `path=` for the workspace and `prompt=` for the worker prompt.
+3. Otherwise, say plainly: "Next: paste this prompt into a fresh worker chat," then include the exact `$bounded-implementer` prompt in a fenced `text` block.
+
+In every worker-launch path, name the back-handoff path the worker must write.
+
+Do not end with only "queued," "recorded," "active slice updated," or a link to `active-slice.md`. Those are internal state updates; they do not tell the user what to do.
+
+Only use an auto-discovery flow when the worker prompt in `active-slice.md` explicitly supports it. In that case, make the launch action brainless, for example a created thread, a deep link, or the exact command text: "$bounded-implementer continue .codex/audits/<audit-name>/active-slice.md". If both a launch action and raw paste are possible, lead with the launch action and keep the paste-ready prompt as fallback.
+
+For non-worker modes:
+
+- `human-decision`: ask the decision question or give the decision options; do not say a worker is queued.
+- `read-only-subagent`: state that the coordinator will run or request the read-only pass, or provide the exact prompt if the user must start it.
+- `same-chat-role-switch`: state that the user must explicitly approve switching this chat out of coordinator mode before implementation begins.
+- no active slice: say "No active implementation slice remains" and name the next useful action, such as review, commit, publish, close, or a human decision.
+
 ## Verification tiers
 
 Choose the smallest verification tier that supports the claim being made:
@@ -320,6 +343,7 @@ For every implementation slice, produce a slice brief with:
 - non-goals;
 - durable context to read first;
 - execution mode;
+- worker launch action for user-started workers;
 - likely files or areas;
 - evidence anchors for non-obvious design claims;
 - relevant boundaries and integration points;
@@ -344,6 +368,10 @@ Use this template:
 ### Durable context to read first
 
 ### Execution mode
+
+### Worker launch action
+
+For `visible-worker` or `worktree-worker`, include the least-manual launch path available: created Codex thread, Codex deep link, or exact paste-ready prompt. Always keep the exact worker prompt available in this section or immediately below it. For `read-only-subagent`, include the exact read-only prompt when user-started. For `human-decision`, replace this section with the decision question. For `same-chat-role-switch`, state that explicit user approval is required first.
 
 ### Local coordination state
 
@@ -372,7 +400,7 @@ In `Local coordination state`, name:
 - the exact `back-handoffs/YYYY-MM-DD-<slice-name>.md` path the implementer must write;
 - any `reviews/YYYY-MM-DD-<slice-name>.md` path the coordinator expects to use.
 
-In `Execution mode`, name one mode from the worker execution modes list and include one sentence explaining why that mode fits the slice. For `visible-worker` or `worktree-worker`, include a paste-ready `$bounded-implementer` prompt. For `read-only-subagent`, require a compact summary only and no file edits. For `same-chat-role-switch`, state that the user must explicitly approve switching this chat out of coordinator mode.
+In `Execution mode`, name one mode from the worker execution modes list and include one sentence explaining why that mode fits the slice. For `visible-worker` or `worktree-worker`, include the launch path and `$bounded-implementer` prompt in `Worker launch action`. For `read-only-subagent`, require a compact summary only and no file edits. For `same-chat-role-switch`, state that the user must explicitly approve switching this chat out of coordinator mode.
 
 ## When resuming after an implementation worker
 
@@ -389,7 +417,7 @@ In `Execution mode`, name one mode from the worker execution modes list and incl
    - next recommended slice.
 
 6. Update `current.md` so a future session can restart without this coordinator chat.
-7. Replace `active-slice.md` with the next slice brief and paste-ready implementer prompt, or shrink it to "no active slice" if none exists.
+7. Replace `active-slice.md` with the next slice brief and worker launch action, including the paste-ready implementer prompt as fallback, or shrink it to "no active slice" if none exists.
 8. Move obsolete active-slice details out of the hot path when they are no longer needed for the next turn.
 9. Run `wc -l current.md active-slice.md` and fix any hot-path budget violation before final response.
 
@@ -401,7 +429,8 @@ When finishing a coordinator turn, report the parts that matter:
 2. Durable docs updated.
 3. Verification tier and evidence.
 4. Proposed next slice.
-5. Recommended worker execution mode and exact `$bounded-implementer` prompt when a worker should execute the slice.
+5. Recommended worker execution mode and least-manual launch action when a worker should execute the slice: created thread, clickable deep link, or exact `$bounded-implementer` prompt.
+6. The user's next physical action: open the created thread, click the deep link, paste the prompt in a fresh worker chat, answer a decision question, approve same-chat role switch, commit/publish, or close.
 
 Keep final responses compact. If the next action is obvious, lead with it. If the explanation involves architecture, include concrete code evidence before the abstract label.
 

--- a/.agents/skills/repo-audit-coordinator/assets/slice-brief-template.md
+++ b/.agents/skills/repo-audit-coordinator/assets/slice-brief-template.md
@@ -16,6 +16,10 @@
 
 ### Likely files / areas
 
+### Evidence anchors
+
+Name the concrete files, functions, snippets, call path, or diff evidence that makes this slice necessary.
+
 ### Relevant boundaries / integration points
 
 ### Expected behavioral change

--- a/.agents/skills/repo-audit-coordinator/assets/slice-brief-template.md
+++ b/.agents/skills/repo-audit-coordinator/assets/slice-brief-template.md
@@ -8,6 +8,10 @@
 
 ### Execution mode
 
+### Worker launch action
+
+For `visible-worker` or `worktree-worker`, include the least-manual launch path available: created Codex thread, Codex deep link, or exact paste-ready prompt. Always keep the exact worker prompt available in this section or immediately below it. For `read-only-subagent`, include the exact read-only prompt when user-started. For `human-decision`, replace this section with the decision question. For `same-chat-role-switch`, state that explicit user approval is required first.
+
 ### Local coordination state
 
 - Active slice path: `.codex/audits/<audit-name>/active-slice.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,19 @@ Repository-level instructions for AI coding agents working on this monorepo.
 - Do not revert unrelated changes. Assume unrecognized local changes came from the user.
 - When changing behavior, verify with the narrowest useful command first, then broaden verification when the blast radius grows.
 
+## Instruction And Command Consistency
+
+- If an instruction, documented command, or workflow note does not work, first check whether the instruction is stale,
+  incomplete, or being run from the wrong build root. Do not add compatibility code, wrappers, build plumbing, or product
+  behavior just to make a stale instruction true.
+- Prefer fixing the instruction or documentation when the code is already in the right shape. If changing code or tooling
+  still seems like the right fix, make the reason explicit and ask the human before doing it unless the task already
+  requested that exact tooling change.
+- Keep agent-facing instructions current and concise. When adding a new rule, remove or update any nearby stale wording
+  that would point agents in a different direction.
+- When asking the human for direction, ask a concrete action question with the options or consequence named. Do not hand
+  back vague uncertainty.
+
 ## Monorepo Shape
 
 - `rust/`: Cargo workspace for the BPM detector core, plugin, desktop app, WASM demo, shared GUI, MIDI service, and Rust tools. Follow `rust/AGENTS.md` for Rust-specific instructions.

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,7 +34,7 @@ auto-download is enabled, so Gradle can provision JDK 17 when needed. Check what
 
 ## One Command Surface
 
-Use the helper script when you do not remember the exact Cargo invocation:
+From the `rust/` build root, use the helper script when you do not remember the exact Cargo invocation:
 
 ```shell
 scripts/dev.sh help

--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -7,6 +7,9 @@ Rust workspace instructions for AI coding agents working under `rust/`.
 - Make small, reviewable changes. Prefer commits that map to one clear design or behavior step.
 - Discuss non-obvious design choices before implementing them.
 - Do not introduce macros unless the user explicitly agrees first.
+- Avoid macro calls in ordinary Rust code unless they remove meaningful boilerplate or encode an established local
+  pattern. Even familiar macros must earn their use; prefer direct syntax when it is clearer for IDE navigation and human
+  readers.
 - Do not add `#[allow(...)]` lint exceptions without explicit human confirmation.
 - Treat clippy warnings as work to fix. If a lint looks wrong or harmful, stop and explain the tradeoff before changing code.
 - When changing behavior, verify with the narrowest useful command first, then broaden verification when the blast radius grows.
@@ -17,6 +20,8 @@ Rust workspace instructions for AI coding agents working under `rust/`.
 - Run Cargo commands from this `rust/` directory unless a task explicitly targets the repository root.
 - `rustfmt` is intentionally run with nightly.
 - Keep `clippy::pedantic` enabled at workspace level.
+- Do not blindly trust idioms that are common in training data, examples, or generic Rust advice. Check whether the
+  pattern improves this repository's readability, tooling, and maintenance before using it.
 - Prefer type-safe representations over sentinel values. If a value has an unset/error/special state, encode that state in the type.
 - Avoid false reuse. If a new helper/protocol makes callers prove a variant is impossible with `unreachable!`, `debug_assert`, or "cannot happen here" comments, split the type or move the shared representation later in the flow. If a caller already knows the only valid case, keep the direct code there instead of routing through a generic policy method.
 - Before keeping a new abstraction, check that it models production code that exists now. Do not add variants, traits, or policy layers for possible future cases; add them when the future case exists.

--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -21,6 +21,10 @@ Rust workspace instructions for AI coding agents working under `rust/`.
 - The Rust helper script is `rust/scripts/dev.sh`; repository docs that say `scripts/dev.sh ...` assume the command is
   being run from `rust/`. If that command appears missing from the repository root, use the documented `cd rust` context
   rather than adding a root wrapper.
+- Plugin task-executor tests bind localhost TCP sockets with `TcpListener`. In Codex sandboxed runs, Rust test commands
+  that include `midi-bpm-detector-plugin` or the whole workspace predictably fail with `Operation not permitted` unless
+  the command has elevated sandbox permissions. Request that permission up front for those test commands; do not run a
+  sandboxed probe just to rediscover the known localhost-bind failure.
 - `rustfmt` is intentionally run with nightly.
 - Keep `clippy::pedantic` enabled at workspace level.
 - Do not blindly trust idioms that are common in training data, examples, or generic Rust advice. Check whether the

--- a/rust/AGENTS.md
+++ b/rust/AGENTS.md
@@ -18,6 +18,9 @@ Rust workspace instructions for AI coding agents working under `rust/`.
 ## Rust And Tooling
 
 - Run Cargo commands from this `rust/` directory unless a task explicitly targets the repository root.
+- The Rust helper script is `rust/scripts/dev.sh`; repository docs that say `scripts/dev.sh ...` assume the command is
+  being run from `rust/`. If that command appears missing from the repository root, use the documented `cd rust` context
+  rather than adding a root wrapper.
 - `rustfmt` is intentionally run with nightly.
 - Keep `clippy::pedantic` enabled at workspace level.
 - Do not blindly trust idioms that are common in training data, examples, or generic Rust advice. Check whether the

--- a/rust/crates/desktop/src/live_parameters.rs
+++ b/rust/crates/desktop/src/live_parameters.rs
@@ -262,12 +262,10 @@ where
 
     fn set_interpolation_duration(&mut self, val: Duration) {
         self.config.gui_config.interpolation_duration = val;
-        self.propagate_dynamic_changes();
     }
 
     fn set_interpolation_curve(&mut self, val: f32) {
         self.config.gui_config.interpolation_curve = val;
-        self.propagate_dynamic_changes();
     }
 }
 

--- a/rust/crates/desktop/tests/unit/live_parameters.rs
+++ b/rust/crates/desktop/tests/unit/live_parameters.rs
@@ -6,7 +6,10 @@ use std::{
 
 use bpm_detection_core::{
     bpm_detection_receiver::BPMDetectionReceiver,
-    parameters::{DynamicBPMDetectionConfig, StaticBPMDetectionConfig, StaticBPMDetectionConfigAccessor},
+    parameters::{
+        DynamicBPMDetectionConfig, DynamicBPMDetectionConfigAccessor, StaticBPMDetectionConfig,
+        StaticBPMDetectionConfigAccessor,
+    },
 };
 use bpm_detection_midi::MidiServiceConfig;
 use gui::{GUIConfig, GUIConfigAccessor};
@@ -72,16 +75,33 @@ fn static_parameter_setter_propagates_static_config() {
 }
 
 #[test]
-fn gui_parameter_setter_propagates_dynamic_config() {
+fn dynamic_parameter_setter_propagates_dynamic_config() {
     let static_changes = Arc::new(StdMutex::new(Vec::new()));
     let dynamic_changes = Arc::new(StdMutex::new(Vec::new()));
     let mut config = base_config(Arc::clone(&static_changes), Arc::clone(&dynamic_changes));
 
-    config.set_interpolation_duration(Duration::from_millis(250));
+    config.set_beats_lookback(12);
 
     let static_changes = static_changes.lock().expect("static changes lock should not be poisoned");
     let dynamic_changes = dynamic_changes.lock().expect("dynamic changes lock should not be poisoned");
     assert!(static_changes.is_empty());
     assert_eq!(dynamic_changes.len(), 1);
+    assert_eq!(dynamic_changes[0].beats_lookback, 12);
+}
+
+#[test]
+fn gui_parameter_setters_update_local_config_without_propagating_detection_config() {
+    let static_changes = Arc::new(StdMutex::new(Vec::new()));
+    let dynamic_changes = Arc::new(StdMutex::new(Vec::new()));
+    let mut config = base_config(Arc::clone(&static_changes), Arc::clone(&dynamic_changes));
+
+    config.set_interpolation_duration(Duration::from_millis(250));
+    config.set_interpolation_curve(0.35);
+
+    let static_changes = static_changes.lock().expect("static changes lock should not be poisoned");
+    let dynamic_changes = dynamic_changes.lock().expect("dynamic changes lock should not be poisoned");
+    assert!(static_changes.is_empty());
+    assert!(dynamic_changes.is_empty());
     assert_eq!(config.interpolation_duration(), Duration::from_millis(250));
+    assert!((config.interpolation_curve() - 0.35).abs() < f32::EPSILON);
 }

--- a/rust/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
@@ -29,7 +29,6 @@ pub struct BaseConfig {
     delayed_update_gui_config: Option<Instant>,
     delayed_update_static_bpm_detection_config: Option<Instant>,
     pub has_config_changes_via_ui: bool,
-    pub send_tempo_changed: ArcAtomicBool,
 }
 
 impl BaseConfig {
@@ -50,7 +49,6 @@ impl BaseConfig {
             delayed_update_static_bpm_detection_config: None,
             has_config_changes_via_ui: false,
             params,
-            send_tempo_changed: ArcAtomicBool::default(),
         }
     }
 
@@ -396,11 +394,10 @@ impl GUIConfigAccessor for LiveConfig<'_> {
 
 impl BPMDetectionConfig for LiveConfig<'_> {
     fn get_send_tempo(&self) -> bool {
-        self.base_config.config.send_tempo.load(Ordering::Relaxed)
+        self.base_config.config.send_tempo.enabled()
     }
 
     fn set_send_tempo(&mut self, enabled: bool) {
-        self.base_config.config.send_tempo.store(enabled, Ordering::SeqCst);
-        self.base_config.send_tempo_changed.store(true, Ordering::SeqCst);
+        self.base_config.config.send_tempo.set_from_gui(enabled);
     }
 }

--- a/rust/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/bpm_detector_configuration.rs
@@ -26,6 +26,7 @@ pub struct BaseConfig {
     async_executor: AsyncExecutor<MidiBpmDetector>,
     force_evaluate_bpm_detection: ArcAtomicBool,
     delayed_update_dynamic_bpm_detection_config: Option<Instant>,
+    delayed_update_gui_config: Option<Instant>,
     delayed_update_static_bpm_detection_config: Option<Instant>,
     pub has_config_changes_via_ui: bool,
     pub send_tempo_changed: ArcAtomicBool,
@@ -45,6 +46,7 @@ impl BaseConfig {
             async_executor,
             force_evaluate_bpm_detection,
             delayed_update_dynamic_bpm_detection_config: None,
+            delayed_update_gui_config: None,
             delayed_update_static_bpm_detection_config: None,
             has_config_changes_via_ui: false,
             params,
@@ -66,6 +68,13 @@ impl BaseConfig {
         }
     }
 
+    fn delay_gui_changes(&mut self) {
+        self.has_config_changes_via_ui = true;
+        if self.delayed_update_gui_config.is_none() {
+            self.delayed_update_gui_config = Some(Instant::now());
+        }
+    }
+
     pub fn apply_delayed_updates(&mut self) {
         if self
             .delayed_update_static_bpm_detection_config
@@ -79,6 +88,17 @@ impl BaseConfig {
             self.async_executor.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Gui));
             self.delayed_update_static_bpm_detection_config = None;
             info!("apply static params");
+        }
+        if self
+            .delayed_update_gui_config
+            .is_some_and(|instant| instant.elapsed() > GUI_PARAMETER_SYNC_COALESCING_WINDOW)
+        {
+            {
+                *self.shared_config.write() = self.config.clone();
+            }
+            self.async_executor.execute_background(Task::GUIConfig(ParameterSyncOrigin::Gui));
+            self.delayed_update_gui_config = None;
+            info!("apply GUI params");
         }
         if self
             .delayed_update_dynamic_bpm_detection_config
@@ -364,13 +384,13 @@ impl GUIConfigAccessor for LiveConfig<'_> {
     fn set_interpolation_duration(&mut self, val: Duration) {
         self.base_config.config.gui_config.interpolation_duration = val;
         apply_duration_param(&self.base_config.params.gui_params.interpolation_duration, val, self.param_setter);
-        self.base_config.delay_dynamic_changes();
+        self.base_config.delay_gui_changes();
     }
 
     fn set_interpolation_curve(&mut self, val: f32) {
         self.base_config.config.gui_config.interpolation_curve = val;
         apply_float_param(&self.base_config.params.gui_params.interpolation_curve, val, self.param_setter);
-        self.base_config.delay_dynamic_changes();
+        self.base_config.delay_gui_changes();
     }
 }
 

--- a/rust/crates/midi-bpm-detector-plugin/src/gui.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/gui.rs
@@ -32,14 +32,12 @@ impl GuiEditor {
             self.force_evaluate_bpm_detection.clone(),
             self.params.clone(),
         );
-        let send_tempo_changed = live_config.send_tempo_changed.clone();
         let (gui_remote, gui_builder) = create_gui(live_config);
         gui_remote.receive_keystrokes({
             let send_tempo = config.send_tempo.clone();
             Box::new(move |key| {
                 if key.to_lowercase() == "t" {
-                    send_tempo.fetch_xor(true, Ordering::Acquire);
-                    send_tempo_changed.store(true, Ordering::Release);
+                    send_tempo.toggle_from_shortcut();
                 }
             })
         });
@@ -53,12 +51,7 @@ impl GuiEditor {
         let should_drop = match (self.editor_state.is_open(), self.bpm_detection_app.as_mut()) {
             (true, Some(BPMDetectionApp { base_config, bpm_detection_gui })) => {
                 let mut live_config = LiveConfig { base_config, param_setter };
-                if live_config
-                    .base_config
-                    .send_tempo_changed
-                    .compare_exchange(true, false, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-                {
+                if live_config.base_config.config.send_tempo.take_host_param_update_request() {
                     let send_tempo = live_config.get_send_tempo();
                     param_setter.begin_set_parameter(&self.params.send_tempo);
                     param_setter.set_parameter(&self.params.send_tempo, send_tempo);

--- a/rust/crates/midi-bpm-detector-plugin/src/lib.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/lib.rs
@@ -63,6 +63,7 @@ pub struct MidiBpmDetector {
     task_executor_handoff: Option<task_executor::TaskExecutor>,
     gui_editor_handoff: Option<GuiEditor>,
     static_bpm_detection_config_changed_at: DeferredConfigUpdate,
+    gui_config_changed_at: DeferredConfigUpdate,
     dynamic_bpm_detection_config_changed_at: DeferredConfigUpdate,
 }
 
@@ -138,11 +139,13 @@ impl Default for MidiBpmDetector {
         let bpm_detection = BPMDetection::new(config.static_bpm_detection_config.clone());
 
         let static_bpm_detection_config_changed_at = DeferredConfigUpdate::pending_initial_sync();
+        let gui_config_changed_at = DeferredConfigUpdate::pending_initial_sync();
         let dynamic_bpm_detection_config_changed_at = DeferredConfigUpdate::pending_initial_sync();
 
         let params = Arc::new(MidiBpmDetectorParams::new(
             &mut config,
             &static_bpm_detection_config_changed_at,
+            &gui_config_changed_at,
             &dynamic_bpm_detection_config_changed_at,
             &current_sample,
             &daw_port,
@@ -186,6 +189,7 @@ impl Default for MidiBpmDetector {
             task_executor_handoff: Some(task_executor),
             gui_editor_handoff: Some(gui_editor),
             static_bpm_detection_config_changed_at,
+            gui_config_changed_at,
             dynamic_bpm_detection_config_changed_at,
         }
     }
@@ -273,6 +277,9 @@ impl Plugin for MidiBpmDetector {
         let delay_by = duration_to_sample(sample_rate, HOST_PARAMETER_SYNC_COALESCING_WINDOW);
         Self::execute_at_delay(current_sample, delay_by, &self.static_bpm_detection_config_changed_at, || {
             context.execute_background(Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Host));
+        });
+        Self::execute_at_delay(current_sample, delay_by, &self.gui_config_changed_at, || {
+            context.execute_background(Task::GUIConfig(ParameterSyncOrigin::Host));
         });
         Self::execute_at_delay(current_sample, delay_by, &self.dynamic_bpm_detection_config_changed_at, || {
             context.execute_background(Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Host));

--- a/rust/crates/midi-bpm-detector-plugin/src/plugin_config.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/plugin_config.rs
@@ -1,10 +1,68 @@
+use std::sync::atomic::Ordering;
+
 use bpm_detection_core::parameters::{DynamicBPMDetectionConfig, StaticBPMDetectionConfig};
 use errors::error_backtrace;
 use gui::GUIConfig;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sync::ArcAtomicBool;
 
 const CONFIG: &str = include_str!("../config/base_config.toml");
+
+#[derive(Clone, Debug, Default)]
+pub struct SendTempoOutputState {
+    enabled: ArcAtomicBool,
+    host_param_update_requested: ArcAtomicBool,
+}
+
+impl SendTempoOutputState {
+    #[must_use]
+    pub fn new(enabled: bool) -> Self {
+        Self { enabled: ArcAtomicBool::new(enabled), host_param_update_requested: ArcAtomicBool::default() }
+    }
+
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled.load(Ordering::Relaxed)
+    }
+
+    pub fn set_from_host(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::Relaxed);
+        self.host_param_update_requested.store(false, Ordering::Relaxed);
+    }
+
+    pub fn set_from_gui(&self, enabled: bool) {
+        self.enabled.store(enabled, Ordering::SeqCst);
+        self.host_param_update_requested.store(true, Ordering::SeqCst);
+    }
+
+    pub fn toggle_from_shortcut(&self) {
+        self.enabled.fetch_xor(true, Ordering::Acquire);
+        self.host_param_update_requested.store(true, Ordering::Release);
+    }
+
+    #[must_use]
+    pub fn take_host_param_update_request(&self) -> bool {
+        self.host_param_update_requested.take(Ordering::Relaxed)
+    }
+}
+
+impl Serialize for SendTempoOutputState {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_bool(self.enabled.load(Ordering::SeqCst))
+    }
+}
+
+impl<'de> Deserialize<'de> for SendTempoOutputState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        bool::deserialize(deserializer).map(Self::new)
+    }
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -13,7 +71,7 @@ pub struct PluginConfig {
     pub gui_config: GUIConfig,
     pub dynamic_bpm_detection_config: DynamicBPMDetectionConfig,
     pub static_bpm_detection_config: StaticBPMDetectionConfig,
-    pub send_tempo: ArcAtomicBool,
+    pub send_tempo: SendTempoOutputState,
 }
 
 impl PluginConfig {

--- a/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
@@ -121,6 +121,17 @@ impl PluginDynamicParams {
     }
 }
 
+impl PluginGUIParams {
+    pub(crate) fn read_gui_config(&self) -> GUIConfig {
+        GUIConfig {
+            interpolation_duration: std::time::Duration::from_secs_f32(
+                self.interpolation_duration.unmodulated_plain_value(),
+            ),
+            interpolation_curve: self.interpolation_curve.unmodulated_plain_value(),
+        }
+    }
+}
+
 struct DynamicRemoteControlParams<'params, 'page, Page> {
     params: &'params PluginDynamicParams,
     page: &'page mut Page,
@@ -273,16 +284,19 @@ impl MidiBpmDetectorParams {
     pub fn new(
         config: &mut PluginConfig,
         static_bpm_detection_config_changed_at: &DeferredConfigUpdate,
+        gui_config_changed_at: &DeferredConfigUpdate,
         dynamic_bpm_detection_config_changed_at: &DeferredConfigUpdate,
         current_sample: &Arc<AtomicUsize>,
         daw_port: &ArcAtomicOptionNonZeroU16,
     ) -> Self {
         let static_updater_factory =
             UpdaterFactory::new(current_sample.clone(), static_bpm_detection_config_changed_at.clone());
+        let gui_updater_factory = UpdaterFactory::new(current_sample.clone(), gui_config_changed_at.clone());
         let dynamic_updater_factory =
             UpdaterFactory::new(current_sample.clone(), dynamic_bpm_detection_config_changed_at.clone());
         let update_static_changed_at_f32 = static_updater_factory.update_changed_at();
         let update_static_changed_at_u16 = static_updater_factory.update_changed_at();
+        let update_gui_changed_at_f32 = gui_updater_factory.update_changed_at();
         let update_dynamic_changed_at_f32 = dynamic_updater_factory.update_changed_at();
         let update_dynamic_changed_at_u8 = dynamic_updater_factory.update_changed_at();
         let dynamic_config = &config.dynamic_bpm_detection_config;
@@ -305,12 +319,12 @@ impl MidiBpmDetectorParams {
                 interpolation_duration: to_plugin_duration_param(
                     &gui_parameters.interpolation_duration(),
                     &config.gui_config,
-                    &update_dynamic_changed_at_f32,
+                    &update_gui_changed_at_f32,
                 ),
                 interpolation_curve: to_plugin_float_param(
                     &gui_parameters.interpolation_curve(),
                     &config.gui_config,
-                    &update_dynamic_changed_at_f32,
+                    &update_gui_changed_at_f32,
                 ),
             },
             static_params: PluginStaticParams {

--- a/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
@@ -132,6 +132,28 @@ impl PluginGUIParams {
     }
 }
 
+impl PluginStaticParams {
+    pub(crate) fn read_static_config(&self) -> StaticBPMDetectionConfig {
+        StaticBPMDetectionConfig {
+            bpm_center: self.bpm_center.unmodulated_plain_value(),
+            bpm_range: self.bpm_range.unmodulated_plain_value() as u16,
+            sample_rate: self.sample_rate.unmodulated_plain_value() as u16,
+            normal_distribution: self.normal_distribution.read_config(),
+        }
+    }
+}
+
+impl NormalDistributionParams {
+    fn read_config(&self) -> NormalDistributionConfig {
+        NormalDistributionConfig {
+            std_dev: f64::from(self.std_dev.unmodulated_plain_value()),
+            resolution: self.resolution.unmodulated_plain_value(),
+            cutoff: self.cutoff.unmodulated_plain_value(),
+            factor: self.factor.unmodulated_plain_value(),
+        }
+    }
+}
+
 struct DynamicRemoteControlParams<'params, 'page, Page> {
     params: &'params PluginDynamicParams,
     page: &'page mut Page,

--- a/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/plugin_parameters.rs
@@ -307,14 +307,12 @@ impl MidiBpmDetectorParams {
 
         Self {
             editor_state: EguiState::from_size(1200, 600),
-            send_tempo: BoolParam::new("Send tempo", config.send_tempo.load(Ordering::Relaxed)).with_callback(
-                Arc::new({
-                    let send_tempo = config.send_tempo.clone();
-                    move |value| {
-                        send_tempo.store(value, Ordering::Relaxed);
-                    }
-                }),
-            ),
+            send_tempo: BoolParam::new("Send tempo", config.send_tempo.enabled()).with_callback(Arc::new({
+                let send_tempo = config.send_tempo.clone();
+                move |value| {
+                    send_tempo.set_from_host(value);
+                }
+            })),
             gui_params: PluginGUIParams {
                 interpolation_duration: to_plugin_duration_param(
                     &gui_parameters.interpolation_duration(),

--- a/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -12,7 +12,6 @@ use bpm_detection_core::{
 use crossbeam::atomic::AtomicCell;
 use errors::{LogErrorWithExt, error, info};
 use gui::GuiRemote;
-use nih_plug::params::Param;
 use ringbuf::{SharedRb, consumer::Consumer, storage::Array, wrap::frozen::Frozen};
 use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
 
@@ -106,23 +105,7 @@ impl TaskExecutor {
                     ParameterSyncOrigin::Host => {
                         let config = {
                             let mut config = self.config.write();
-                            config.static_bpm_detection_config.bpm_center =
-                                self.params.static_params.bpm_center.unmodulated_plain_value();
-                            config.static_bpm_detection_config.bpm_range =
-                                self.params.static_params.bpm_range.unmodulated_plain_value() as u16;
-                            config.static_bpm_detection_config.sample_rate =
-                                self.params.static_params.sample_rate.unmodulated_plain_value() as u16;
-
-                            config.static_bpm_detection_config.normal_distribution.std_dev = f64::from(
-                                self.params.static_params.normal_distribution.std_dev.unmodulated_plain_value(),
-                            );
-                            config.static_bpm_detection_config.normal_distribution.resolution =
-                                self.params.static_params.normal_distribution.resolution.unmodulated_plain_value();
-                            config.static_bpm_detection_config.normal_distribution.cutoff =
-                                self.params.static_params.normal_distribution.cutoff.unmodulated_plain_value();
-                            config.static_bpm_detection_config.normal_distribution.factor =
-                                self.params.static_params.normal_distribution.factor.unmodulated_plain_value();
-
+                            config.static_bpm_detection_config = self.params.static_params.read_static_config();
                             config.static_bpm_detection_config.clone()
                         };
                         self.gui_must_update_config.store(true, Ordering::Relaxed);

--- a/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -27,6 +27,7 @@ const TEMPO_CONTROLLER_FRAME_BYTES: usize = 8;
 pub enum Task {
     ProcessNotes { force_evaluate_bpm_detection: bool },
     StaticBPMDetectionConfig(ParameterSyncOrigin),
+    GUIConfig(ParameterSyncOrigin),
     DynamicBPMDetectionConfig(ParameterSyncOrigin),
 }
 
@@ -60,12 +61,7 @@ impl TaskExecutor {
         match task {
             Task::ProcessNotes { force_evaluate_bpm_detection } => {
                 let mut evaluate_bpm_detection = force_evaluate_bpm_detection;
-                if !self.params.editor_state.is_open() {
-                    self.gui_remote = None;
-                }
-                if let Some(new_gui_remote) = self.gui_remote_receiver.take() {
-                    self.gui_remote = Some(new_gui_remote);
-                }
+                self.refresh_gui_remote();
                 for event in self.events_receiver.pop_iter() {
                     match event {
                         Event::TimedNoteOn(timed_note_on) => {
@@ -138,19 +134,26 @@ impl TaskExecutor {
                     }
                 }
             }
+            Task::GUIConfig(sync) => {
+                if sync == ParameterSyncOrigin::Host {
+                    {
+                        let mut config = self.config.write();
+                        config.gui_config = self.params.gui_params.read_gui_config();
+                    }
+                    self.gui_must_update_config.store(true, Ordering::Relaxed);
+                }
+
+                self.refresh_gui_remote();
+                if let Some(gui_remote) = &mut self.gui_remote {
+                    gui_remote.request_repaint();
+                }
+            }
             Task::DynamicBPMDetectionConfig(sync) => match sync {
                 ParameterSyncOrigin::Host => {
                     {
                         let mut config = self.config.write();
 
-                        config.gui_config.interpolation_duration = Duration::from_secs_f32(
-                            self.params.gui_params.interpolation_duration.unmodulated_plain_value(),
-                        );
-                        config.gui_config.interpolation_curve =
-                            self.params.gui_params.interpolation_curve.unmodulated_plain_value();
-
                         config.dynamic_bpm_detection_config = self.params.dynamic_params.read_dynamic_config();
-                        config.send_tempo.store(self.params.send_tempo.unmodulated_plain_value(), Ordering::Relaxed);
                         self.dynamic_bpm_detection_config = config.dynamic_bpm_detection_config.clone();
                     }
                     self.gui_must_update_config.store(true, Ordering::Relaxed);
@@ -161,6 +164,15 @@ impl TaskExecutor {
                     self.dynamic_bpm_detection_config = config.dynamic_bpm_detection_config.clone();
                 }
             },
+        }
+    }
+
+    fn refresh_gui_remote(&mut self) {
+        if !self.params.editor_state.is_open() {
+            self.gui_remote = None;
+        }
+        if let Some(new_gui_remote) = self.gui_remote_receiver.take() {
+            self.gui_remote = Some(new_gui_remote);
         }
     }
 }

--- a/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -16,7 +16,11 @@ use nih_plug::params::Param;
 use ringbuf::{SharedRb, consumer::Consumer, storage::Array, wrap::frozen::Frozen};
 use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
 
-use crate::{MidiBpmDetectorParams, parameter_sync::ParameterSyncOrigin, plugin_config::PluginConfig};
+use crate::{
+    MidiBpmDetectorParams,
+    parameter_sync::ParameterSyncOrigin,
+    plugin_config::{PluginConfig, SendTempoOutputState},
+};
 
 const TEMPO_CONTROLLER_CONNECT_TIMEOUT: Duration = Duration::from_millis(10);
 const TEMPO_CONTROLLER_WRITE_TIMEOUT: Duration = Duration::from_millis(10);
@@ -48,7 +52,7 @@ pub struct TaskExecutor {
     pub gui_must_update_config: ArcAtomicBool,
     pub daw_port: ArcAtomicOptionNonZeroU16,
     pub daw_connection: Option<TcpStream>,
-    pub send_tempo: ArcAtomicBool,
+    pub send_tempo: SendTempoOutputState,
 }
 
 impl TaskExecutor {
@@ -80,7 +84,7 @@ impl TaskExecutor {
                     let bpm_detection_result = self.bpm_detection.compute_bpm(&self.dynamic_bpm_detection_config);
 
                     if let (Some((_, bpm)), true, Some(daw_connection)) =
-                        (bpm_detection_result, self.send_tempo.load(Ordering::Relaxed), &mut self.daw_connection)
+                        (bpm_detection_result, self.send_tempo.enabled(), &mut self.daw_connection)
                         && write_bpm_to_tempo_controller(daw_connection, bpm).is_err()
                     {
                         self.daw_connection = None;

--- a/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/src/task_executor.rs
@@ -148,9 +148,6 @@ impl TaskExecutor {
                         );
                         config.gui_config.interpolation_curve =
                             self.params.gui_params.interpolation_curve.unmodulated_plain_value();
-                        config.gui_config.interpolation_duration = Duration::from_secs_f32(
-                            self.params.gui_params.interpolation_duration.unmodulated_plain_value(),
-                        );
 
                         config.dynamic_bpm_detection_config = self.params.dynamic_params.read_dynamic_config();
                         config.send_tempo.store(self.params.send_tempo.unmodulated_plain_value(), Ordering::Relaxed);

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_config.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_config.rs
@@ -1,6 +1,54 @@
 use super::*;
 
 #[test]
+fn send_tempo_output_state_serializes_as_toml_boolean() {
+    let config = PluginConfig { send_tempo: SendTempoOutputState::new(false), ..PluginConfig::default() };
+
+    let serialized = toml::to_string(&config).expect("plugin config should serialize");
+    let parsed: toml::Table = serialized.parse().expect("serialized config should be TOML");
+
+    assert_eq!(parsed["send_tempo"].as_bool(), Some(false));
+}
+
+#[test]
+fn send_tempo_output_state_deserializes_from_toml_boolean() {
+    let config = PluginConfig::from_toml(&CONFIG.replace("send_tempo = true", "send_tempo = false"))
+        .expect("boolean send_tempo should deserialize");
+
+    assert!(!config.send_tempo.enabled());
+}
+
+#[test]
+fn send_tempo_output_state_tracks_host_param_mirror_by_origin() {
+    let state = SendTempoOutputState::new(false);
+
+    state.set_from_host(true);
+    assert!(state.enabled());
+    assert!(!state.take_host_param_update_request());
+
+    state.set_from_gui(false);
+    assert!(!state.enabled());
+    assert!(state.take_host_param_update_request());
+    assert!(!state.take_host_param_update_request());
+
+    state.set_from_gui(false);
+    state.set_from_host(true);
+    assert!(state.enabled());
+    assert!(!state.take_host_param_update_request());
+
+    state.toggle_from_shortcut();
+    assert!(!state.enabled());
+    state.set_from_host(true);
+    assert!(state.enabled());
+    assert!(!state.take_host_param_update_request());
+
+    state.toggle_from_shortcut();
+    assert!(!state.enabled());
+    assert!(state.take_host_param_update_request());
+    assert!(!state.take_host_param_update_request());
+}
+
+#[test]
 fn plugin_config_rejects_stale_dynamic_parameter_keys() {
     let config_with_stale_key = CONFIG.replace("high_tempo_bias_weight", "high_tempo_bias");
 

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_parameters.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_parameters.rs
@@ -30,7 +30,8 @@ fn plugin_on_off_params_initialize_enabled_state_from_matching_config_field() {
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
 
-    let params = MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &current_sample, &daw_port);
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
 
     assert!(params.dynamic_params.velocity_current_note_weight.is_enabled());
     assert!(!params.dynamic_params.velocity_note_from_weight.is_enabled());
@@ -42,7 +43,8 @@ fn dynamic_remote_controls_expose_every_dynamic_parameter() {
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
-    let params = MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &current_sample, &daw_port);
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
     let mut remote_controls = RemoteControlNames(Vec::new());
 
     params.dynamic_params.add_remote_controls(&mut remote_controls);
@@ -71,7 +73,8 @@ fn static_plugin_parameter_ids_match_config_field_names() {
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
-    let params = MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &current_sample, &daw_port);
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
     let param_ids = params.param_map().into_iter().map(|(id, _, _)| id).collect::<Vec<_>>();
 
     assert!(param_ids.contains(&String::from("bpm_center")));
@@ -86,7 +89,8 @@ fn dynamic_on_off_persistent_keys_match_parameter_ids() {
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
-    let params = MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &current_sample, &daw_port);
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
     let persistent_keys = params.serialize_fields().into_keys().collect::<Vec<_>>();
 
     for key in [
@@ -125,7 +129,8 @@ fn dynamic_params_read_initialized_host_values_as_dynamic_config() {
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
-    let params = MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &current_sample, &daw_port);
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
 
     assert_eq!(params.dynamic_params.read_dynamic_config(), source_dynamic_config);
 }

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_parameters.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/plugin_parameters.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, atomic::AtomicUsize};
 
-use bpm_detection_core::parameters::DynamicBPMDetectionConfig;
+use bpm_detection_core::parameters::{DynamicBPMDetectionConfig, NormalDistributionConfig, StaticBPMDetectionConfig};
 use nih_plug::prelude::{Param, Params, RemoteControlsPage};
 
 use super::*;
@@ -133,4 +133,23 @@ fn dynamic_params_read_initialized_host_values_as_dynamic_config() {
         MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
 
     assert_eq!(params.dynamic_params.read_dynamic_config(), source_dynamic_config);
+}
+
+#[test]
+fn static_params_read_initialized_host_values_as_static_config() {
+    let source_static_config = StaticBPMDetectionConfig {
+        bpm_center: 111.5,
+        bpm_range: 48,
+        sample_rate: 720,
+        normal_distribution: NormalDistributionConfig { std_dev: 18.25, resolution: 0.5, cutoff: 128.0, factor: 32.0 },
+    };
+    let mut config =
+        PluginConfig { static_bpm_detection_config: source_static_config.clone(), ..PluginConfig::default() };
+    let current_sample = Arc::new(AtomicUsize::new(0));
+    let changed_at = DeferredConfigUpdate::idle();
+    let daw_port = ArcAtomicOptionNonZeroU16::none();
+    let params =
+        MidiBpmDetectorParams::new(&mut config, &changed_at, &changed_at, &changed_at, &current_sample, &daw_port);
+
+    assert_eq!(params.static_params.read_static_config(), source_static_config);
 }

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
@@ -5,7 +5,11 @@ use std::{
     time::Duration as StdDuration,
 };
 
-use bpm_detection_core::{TimedNoteOn, note_events::NoteOn};
+use bpm_detection_core::{
+    TimedNoteOn,
+    note_events::NoteOn,
+    parameters::{NormalDistributionConfig, StaticBPMDetectionConfig},
+};
 use chrono::Duration as ChronoDuration;
 use parameter::OnOff;
 use ringbuf::{StaticRb, traits::Split};
@@ -119,6 +123,91 @@ fn host_origin_dynamic_sync_copies_dynamic_values_and_forces_recompute() {
     assert_eq!(config.dynamic_bpm_detection_config, host_dynamic_config);
     assert!(config.send_tempo.enabled());
     assert_eq!(executor.dynamic_bpm_detection_config, host_dynamic_config);
+    assert!(gui_must_update_config.load(Ordering::Relaxed));
+
+    let mut frame = [0; TEMPO_CONTROLLER_FRAME_BYTES];
+    server.read_exact(&mut frame).unwrap();
+    assert_eq!(u32::from_be_bytes(frame[..4].try_into().unwrap()), TEMPO_CONTROLLER_PAYLOAD_BYTES);
+}
+
+#[test]
+fn host_origin_static_sync_copies_static_values_and_forces_recompute() {
+    let host_static_config = StaticBPMDetectionConfig {
+        bpm_center: 111.5,
+        bpm_range: 48,
+        sample_rate: 720,
+        normal_distribution: NormalDistributionConfig { std_dev: 18.25, resolution: 0.5, cutoff: 128.0, factor: 32.0 },
+    };
+    let mut host_config =
+        PluginConfig { static_bpm_detection_config: host_static_config.clone(), ..PluginConfig::default() };
+    host_config.send_tempo.set_from_host(false);
+
+    let shared_static_config = StaticBPMDetectionConfig {
+        bpm_center: 88.0,
+        bpm_range: 20,
+        sample_rate: 360,
+        normal_distribution: NormalDistributionConfig { std_dev: 24.0, resolution: 0.6, cutoff: 100.0, factor: 40.0 },
+    };
+    let shared_dynamic_config = DynamicBPMDetectionConfig {
+        beats_lookback: 2,
+        normal_distribution_weight: OnOff::Off(0.1),
+        ..Default::default()
+    };
+    let shared_config = Arc::new(RwLock::new(PluginConfig {
+        static_bpm_detection_config: shared_static_config.clone(),
+        dynamic_bpm_detection_config: shared_dynamic_config.clone(),
+        ..PluginConfig::default()
+    }));
+    shared_config.read().send_tempo.set_from_host(true);
+    let current_sample = Arc::new(AtomicUsize::new(0));
+    let changed_at = DeferredConfigUpdate::idle();
+    let daw_port = ArcAtomicOptionNonZeroU16::none();
+    let params = Arc::new(MidiBpmDetectorParams::new(
+        &mut host_config,
+        &changed_at,
+        &changed_at,
+        &changed_at,
+        &current_sample,
+        &daw_port,
+    ));
+    let (_, events_receiver) = StaticRb::<Event, 1000>::default().split();
+    let gui_must_update_config = ArcAtomicBool::new(false);
+    let send_tempo = shared_config.read().send_tempo.clone();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (mut server, _) = listener.accept().unwrap();
+    server.set_read_timeout(Some(StdDuration::from_secs(1))).unwrap();
+    let mut bpm_detection = BPMDetection::new(shared_static_config);
+
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::zero(),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::milliseconds(667),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+
+    let mut executor = TaskExecutor {
+        bpm_detection,
+        dynamic_bpm_detection_config: shared_dynamic_config.clone(),
+        gui_remote: None,
+        params,
+        gui_remote_receiver: Arc::new(AtomicCell::new(None)),
+        events_receiver: events_receiver.freeze(),
+        config: shared_config.clone(),
+        gui_must_update_config: gui_must_update_config.clone(),
+        daw_port,
+        daw_connection: Some(client),
+        send_tempo,
+    };
+
+    executor.execute(Task::StaticBPMDetectionConfig(ParameterSyncOrigin::Host));
+
+    let config = shared_config.read();
+    assert_eq!(config.static_bpm_detection_config, host_static_config);
+    assert_eq!(config.dynamic_bpm_detection_config, shared_dynamic_config);
+    assert_eq!(executor.dynamic_bpm_detection_config, shared_dynamic_config);
     assert!(gui_must_update_config.load(Ordering::Relaxed));
 
     let mut frame = [0; TEMPO_CONTROLLER_FRAME_BYTES];

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
@@ -55,7 +55,7 @@ fn host_origin_dynamic_sync_copies_dynamic_values_and_forces_recompute() {
         gui_config: host_gui_config.clone(),
         ..PluginConfig::default()
     };
-    host_config.send_tempo.store(false, Ordering::Relaxed);
+    host_config.send_tempo.set_from_host(false);
 
     let shared_gui_config =
         gui::GUIConfig { interpolation_duration: StdDuration::from_millis(50), interpolation_curve: 0.1 };
@@ -68,7 +68,7 @@ fn host_origin_dynamic_sync_copies_dynamic_values_and_forces_recompute() {
         gui_config: shared_gui_config.clone(),
         ..PluginConfig::default()
     }));
-    shared_config.read().send_tempo.store(true, Ordering::Relaxed);
+    shared_config.read().send_tempo.set_from_host(true);
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
@@ -117,7 +117,7 @@ fn host_origin_dynamic_sync_copies_dynamic_values_and_forces_recompute() {
     let config = shared_config.read();
     assert_gui_config_eq(&config.gui_config, &shared_gui_config);
     assert_eq!(config.dynamic_bpm_detection_config, host_dynamic_config);
-    assert!(config.send_tempo.load(Ordering::Relaxed));
+    assert!(config.send_tempo.enabled());
     assert_eq!(executor.dynamic_bpm_detection_config, host_dynamic_config);
     assert!(gui_must_update_config.load(Ordering::Relaxed));
 
@@ -143,7 +143,7 @@ fn host_origin_gui_config_sync_copies_host_values_without_forcing_recompute() {
         gui_config: shared_gui_config,
         ..PluginConfig::default()
     }));
-    shared_config.read().send_tempo.store(true, Ordering::Relaxed);
+    shared_config.read().send_tempo.set_from_host(true);
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::Read,
+    io::{ErrorKind, Read},
     net::{Ipv4Addr, TcpListener, TcpStream},
     sync::{Arc, atomic::AtomicUsize},
     time::Duration as StdDuration,
@@ -13,6 +13,11 @@ use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
 
 use super::*;
 use crate::{DeferredConfigUpdate, plugin_config::PluginConfig};
+
+fn assert_gui_config_eq(actual: &gui::GUIConfig, expected: &gui::GUIConfig) {
+    assert_eq!(actual.interpolation_duration, expected.interpolation_duration);
+    assert!((actual.interpolation_curve - expected.interpolation_curve).abs() < f32::EPSILON);
+}
 
 #[test]
 fn tempo_controller_frame_prefixes_big_endian_payload_length() {
@@ -29,7 +34,7 @@ fn tempo_controller_frame_writes_big_endian_bpm() {
 }
 
 #[test]
-fn host_origin_dynamic_sync_copies_host_values_and_forces_recompute() {
+fn host_origin_dynamic_sync_copies_dynamic_values_and_forces_recompute() {
     let host_dynamic_config = DynamicBPMDetectionConfig {
         beats_lookback: 13,
         normal_distribution_weight: OnOff::On(0.9),
@@ -50,22 +55,31 @@ fn host_origin_dynamic_sync_copies_host_values_and_forces_recompute() {
         gui_config: host_gui_config.clone(),
         ..PluginConfig::default()
     };
-    host_config.send_tempo.store(true, Ordering::Relaxed);
+    host_config.send_tempo.store(false, Ordering::Relaxed);
 
+    let shared_gui_config =
+        gui::GUIConfig { interpolation_duration: StdDuration::from_millis(50), interpolation_curve: 0.1 };
     let shared_config = Arc::new(RwLock::new(PluginConfig {
         dynamic_bpm_detection_config: DynamicBPMDetectionConfig {
             beats_lookback: 2,
             normal_distribution_weight: OnOff::Off(0.1),
             ..DynamicBPMDetectionConfig::default()
         },
-        gui_config: gui::GUIConfig { interpolation_duration: StdDuration::from_millis(50), interpolation_curve: 0.1 },
+        gui_config: shared_gui_config.clone(),
         ..PluginConfig::default()
     }));
+    shared_config.read().send_tempo.store(true, Ordering::Relaxed);
     let current_sample = Arc::new(AtomicUsize::new(0));
     let changed_at = DeferredConfigUpdate::idle();
     let daw_port = ArcAtomicOptionNonZeroU16::none();
-    let params =
-        Arc::new(MidiBpmDetectorParams::new(&mut host_config, &changed_at, &changed_at, &current_sample, &daw_port));
+    let params = Arc::new(MidiBpmDetectorParams::new(
+        &mut host_config,
+        &changed_at,
+        &changed_at,
+        &changed_at,
+        &current_sample,
+        &daw_port,
+    ));
     let (_, events_receiver) = StaticRb::<Event, 1000>::default().split();
     let gui_must_update_config = ArcAtomicBool::new(false);
     let send_tempo = shared_config.read().send_tempo.clone();
@@ -101,8 +115,7 @@ fn host_origin_dynamic_sync_copies_host_values_and_forces_recompute() {
     executor.execute(Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Host));
 
     let config = shared_config.read();
-    assert_eq!(config.gui_config.interpolation_duration, host_gui_config.interpolation_duration);
-    assert!((config.gui_config.interpolation_curve - host_gui_config.interpolation_curve).abs() < f32::EPSILON);
+    assert_gui_config_eq(&config.gui_config, &shared_gui_config);
     assert_eq!(config.dynamic_bpm_detection_config, host_dynamic_config);
     assert!(config.send_tempo.load(Ordering::Relaxed));
     assert_eq!(executor.dynamic_bpm_detection_config, host_dynamic_config);
@@ -111,4 +124,78 @@ fn host_origin_dynamic_sync_copies_host_values_and_forces_recompute() {
     let mut frame = [0; TEMPO_CONTROLLER_FRAME_BYTES];
     server.read_exact(&mut frame).unwrap();
     assert_eq!(u32::from_be_bytes(frame[..4].try_into().unwrap()), TEMPO_CONTROLLER_PAYLOAD_BYTES);
+}
+
+#[test]
+fn host_origin_gui_config_sync_copies_host_values_without_forcing_recompute() {
+    let host_gui_config =
+        gui::GUIConfig { interpolation_duration: StdDuration::from_secs_f32(0.82), interpolation_curve: 1.25 };
+    let mut host_config = PluginConfig { gui_config: host_gui_config.clone(), ..PluginConfig::default() };
+    let shared_dynamic_config = DynamicBPMDetectionConfig {
+        beats_lookback: 2,
+        normal_distribution_weight: OnOff::Off(0.1),
+        ..Default::default()
+    };
+    let shared_gui_config =
+        gui::GUIConfig { interpolation_duration: StdDuration::from_millis(50), interpolation_curve: 0.1 };
+    let shared_config = Arc::new(RwLock::new(PluginConfig {
+        dynamic_bpm_detection_config: shared_dynamic_config.clone(),
+        gui_config: shared_gui_config,
+        ..PluginConfig::default()
+    }));
+    shared_config.read().send_tempo.store(true, Ordering::Relaxed);
+    let current_sample = Arc::new(AtomicUsize::new(0));
+    let changed_at = DeferredConfigUpdate::idle();
+    let daw_port = ArcAtomicOptionNonZeroU16::none();
+    let params = Arc::new(MidiBpmDetectorParams::new(
+        &mut host_config,
+        &changed_at,
+        &changed_at,
+        &changed_at,
+        &current_sample,
+        &daw_port,
+    ));
+    let (_, events_receiver) = StaticRb::<Event, 1000>::default().split();
+    let gui_must_update_config = ArcAtomicBool::new(false);
+    let send_tempo = shared_config.read().send_tempo.clone();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (mut server, _) = listener.accept().unwrap();
+    server.set_read_timeout(Some(StdDuration::from_millis(25))).unwrap();
+    let mut bpm_detection = BPMDetection::new(shared_config.read().static_bpm_detection_config.clone());
+
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::zero(),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::milliseconds(667),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+
+    let mut executor = TaskExecutor {
+        bpm_detection,
+        dynamic_bpm_detection_config: shared_dynamic_config.clone(),
+        gui_remote: None,
+        params,
+        gui_remote_receiver: Arc::new(AtomicCell::new(None)),
+        events_receiver: events_receiver.freeze(),
+        config: shared_config.clone(),
+        gui_must_update_config: gui_must_update_config.clone(),
+        daw_port,
+        daw_connection: Some(client),
+        send_tempo,
+    };
+
+    executor.execute(Task::GUIConfig(ParameterSyncOrigin::Host));
+
+    let config = shared_config.read();
+    assert_gui_config_eq(&config.gui_config, &host_gui_config);
+    assert_eq!(config.dynamic_bpm_detection_config, shared_dynamic_config);
+    assert_eq!(executor.dynamic_bpm_detection_config, shared_dynamic_config);
+    assert!(gui_must_update_config.load(Ordering::Relaxed));
+
+    let mut frame = [0; TEMPO_CONTROLLER_FRAME_BYTES];
+    let err = server.read_exact(&mut frame).unwrap_err();
+    assert!(matches!(err.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut));
 }

--- a/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
+++ b/rust/crates/midi-bpm-detector-plugin/tests/unit/task_executor.rs
@@ -1,4 +1,18 @@
+use std::{
+    io::Read,
+    net::{Ipv4Addr, TcpListener, TcpStream},
+    sync::{Arc, atomic::AtomicUsize},
+    time::Duration as StdDuration,
+};
+
+use bpm_detection_core::{TimedNoteOn, note_events::NoteOn};
+use chrono::Duration as ChronoDuration;
+use parameter::OnOff;
+use ringbuf::{StaticRb, traits::Split};
+use sync::{ArcAtomicBool, ArcAtomicOptionNonZeroU16, RwLock};
+
 use super::*;
+use crate::{DeferredConfigUpdate, plugin_config::PluginConfig};
 
 #[test]
 fn tempo_controller_frame_prefixes_big_endian_payload_length() {
@@ -12,4 +26,89 @@ fn tempo_controller_frame_writes_big_endian_bpm() {
     let frame = tempo_controller_frame(123.5);
 
     assert_eq!(frame[4..], 123.5f32.to_be_bytes());
+}
+
+#[test]
+fn host_origin_dynamic_sync_copies_host_values_and_forces_recompute() {
+    let host_dynamic_config = DynamicBPMDetectionConfig {
+        beats_lookback: 13,
+        normal_distribution_weight: OnOff::On(0.9),
+        time_distance_weight: OnOff::On(1.3),
+        velocity_current_note_weight: OnOff::On(1.1),
+        velocity_note_from_weight: OnOff::Off(1.2),
+        in_beat_range_weight: OnOff::Off(1.8),
+        multiplier_weight: OnOff::Off(1.6),
+        subdivision_weight: OnOff::On(1.7),
+        octave_distance_weight: OnOff::Off(1.4),
+        pitch_distance_weight: OnOff::On(1.5),
+        high_tempo_bias_weight: OnOff::Off(2.1),
+    };
+    let host_gui_config =
+        gui::GUIConfig { interpolation_duration: StdDuration::from_secs_f32(0.82), interpolation_curve: 1.25 };
+    let mut host_config = PluginConfig {
+        dynamic_bpm_detection_config: host_dynamic_config.clone(),
+        gui_config: host_gui_config.clone(),
+        ..PluginConfig::default()
+    };
+    host_config.send_tempo.store(true, Ordering::Relaxed);
+
+    let shared_config = Arc::new(RwLock::new(PluginConfig {
+        dynamic_bpm_detection_config: DynamicBPMDetectionConfig {
+            beats_lookback: 2,
+            normal_distribution_weight: OnOff::Off(0.1),
+            ..DynamicBPMDetectionConfig::default()
+        },
+        gui_config: gui::GUIConfig { interpolation_duration: StdDuration::from_millis(50), interpolation_curve: 0.1 },
+        ..PluginConfig::default()
+    }));
+    let current_sample = Arc::new(AtomicUsize::new(0));
+    let changed_at = DeferredConfigUpdate::idle();
+    let daw_port = ArcAtomicOptionNonZeroU16::none();
+    let params =
+        Arc::new(MidiBpmDetectorParams::new(&mut host_config, &changed_at, &changed_at, &current_sample, &daw_port));
+    let (_, events_receiver) = StaticRb::<Event, 1000>::default().split();
+    let gui_must_update_config = ArcAtomicBool::new(false);
+    let send_tempo = shared_config.read().send_tempo.clone();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (mut server, _) = listener.accept().unwrap();
+    server.set_read_timeout(Some(StdDuration::from_secs(1))).unwrap();
+    let mut bpm_detection = BPMDetection::new(shared_config.read().static_bpm_detection_config.clone());
+
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::zero(),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+    bpm_detection.receive_note_on(TimedNoteOn {
+        timestamp: ChronoDuration::milliseconds(667),
+        event: NoteOn { channel: 0, pitch: 60, velocity: 100 },
+    });
+
+    let mut executor = TaskExecutor {
+        bpm_detection,
+        dynamic_bpm_detection_config: DynamicBPMDetectionConfig::default(),
+        gui_remote: None,
+        params,
+        gui_remote_receiver: Arc::new(AtomicCell::new(None)),
+        events_receiver: events_receiver.freeze(),
+        config: shared_config.clone(),
+        gui_must_update_config: gui_must_update_config.clone(),
+        daw_port,
+        daw_connection: Some(client),
+        send_tempo,
+    };
+
+    executor.execute(Task::DynamicBPMDetectionConfig(ParameterSyncOrigin::Host));
+
+    let config = shared_config.read();
+    assert_eq!(config.gui_config.interpolation_duration, host_gui_config.interpolation_duration);
+    assert!((config.gui_config.interpolation_curve - host_gui_config.interpolation_curve).abs() < f32::EPSILON);
+    assert_eq!(config.dynamic_bpm_detection_config, host_dynamic_config);
+    assert!(config.send_tempo.load(Ordering::Relaxed));
+    assert_eq!(executor.dynamic_bpm_detection_config, host_dynamic_config);
+    assert!(gui_must_update_config.load(Ordering::Relaxed));
+
+    let mut frame = [0; TEMPO_CONTROLLER_FRAME_BYTES];
+    server.read_exact(&mut frame).unwrap();
+    assert_eq!(u32::from_be_bytes(frame[..4].try_into().unwrap()), TEMPO_CONTROLLER_PAYLOAD_BYTES);
 }

--- a/rust/crates/wasm/src/lib.rs
+++ b/rust/crates/wasm/src/lib.rs
@@ -260,12 +260,10 @@ impl GUIConfigAccessor for BaseConfig {
 
     fn set_interpolation_duration(&mut self, val: Duration) {
         self.config.gui_config.interpolation_duration = val;
-        self.propagate_dynamic_changes();
     }
 
     fn set_interpolation_curve(&mut self, val: f32) {
         self.config.gui_config.interpolation_curve = val;
-        self.propagate_dynamic_changes();
     }
 }
 

--- a/rust/crates/wasm/tests/unit/lib.rs
+++ b/rust/crates/wasm/tests/unit/lib.rs
@@ -1,9 +1,16 @@
 #![allow(clippy::missing_panics_doc)]
+use bpm_detection_core::parameters::{
+    DynamicBPMDetectionConfig, DynamicBPMDetectionConfigAccessor, StaticBPMDetectionConfig,
+};
 use errors::error_backtrace;
+use futures::channel::mpsc;
+use gui::{GUIConfig, GUIConfigAccessor};
 use parameter::OnOff;
 use serde::{Deserialize, Serialize};
 #[allow(clippy::module_name_repetitions)]
 use wasm_bindgen_test::*;
+
+use super::{BaseConfig, QueueItem, WASMConfig};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
@@ -26,8 +33,49 @@ const CONFIG: &str = "[test]
 enabled = false
 value = 1";
 
+fn base_config(sender: mpsc::Sender<QueueItem>) -> BaseConfig {
+    BaseConfig {
+        config: WASMConfig {
+            gui_config: GUIConfig::default(),
+            dynamic_bpm_detection_config: DynamicBPMDetectionConfig::default(),
+            static_bpm_detection_config: StaticBPMDetectionConfig::default(),
+        },
+        sender,
+    }
+}
+
 #[wasm_bindgen_test]
 fn test_config() {
     let config = Config::default();
     assert_eq!(config.test, OnOff::Off(1.0));
+}
+
+#[wasm_bindgen_test]
+fn gui_parameter_setters_update_local_config_without_queueing_detection_config() {
+    let (sender, mut receiver) = mpsc::channel(4);
+    let mut config = base_config(sender);
+
+    config.set_interpolation_duration(std::time::Duration::from_millis(250));
+    config.set_interpolation_curve(0.35);
+
+    assert!(receiver.try_recv().is_err());
+    assert_eq!(config.interpolation_duration(), std::time::Duration::from_millis(250));
+    assert!((config.interpolation_curve() - 0.35).abs() < f32::EPSILON);
+}
+
+#[wasm_bindgen_test]
+fn dynamic_parameter_setter_queues_dynamic_parameters() {
+    let (sender, mut receiver) = mpsc::channel(4);
+    let mut config = base_config(sender);
+
+    config.set_beats_lookback(12);
+
+    let queued = receiver.try_recv().expect("dynamic update should be queued");
+    match queued {
+        QueueItem::DynamicParameters(dynamic_config) => assert_eq!(dynamic_config.beats_lookback, 12),
+        QueueItem::StaticParameters(_)
+        | QueueItem::Note(_)
+        | QueueItem::DelayedDynamicUpdate
+        | QueueItem::DelayedStaticUpdate => panic!("expected dynamic parameters"),
+    }
 }


### PR DESCRIPTION
Summary
- Separate display-only GUI/config changes from dynamic BPM recomputation across plugin, desktop, and WASM paths.
- Collocate send_tempo runtime output state with its host-param mirror flag.
- Move static host config reads behind PluginStaticParams and add focused host-origin sync coverage.
- Harden repo agent/docs guidance so stale or misread instructions are fixed as instructions first, not by adding compatibility wrappers.

Verification
- git diff --check
- cargo +nightly fmt --all -- --check
- cargo check --locked --workspace --exclude wasm --all-targets
- cargo test --locked --workspace --exclude wasm --all-targets
- cargo clippy --locked --workspace --exclude wasm --all-targets -- -D warnings
- cargo check --locked -p wasm --target wasm32-unknown-unknown
- cargo test --locked -p wasm --target wasm32-unknown-unknown
- cargo clippy --locked -p wasm --target wasm32-unknown-unknown -- -D warnings
