### PR TITLE
Fix Cmd+Q lifecycle in hosted plugin GUI

### DIFF
--- a/docs/runtime-lifecycle.md
+++ b/docs/runtime-lifecycle.md
@@ -19,6 +19,9 @@ they actually own. Bootstrap knows the graph. The graph should not turn into a r
   so native MIDI thread ownership stays inside `bpm_detection_midi`.
 - **Remote receiver:** a narrow receiver used by BPM producers to push display data. `GuiRemote` implements
   `BPMDetectionReceiver` and owns repaint requests plus shared GUI-facing state.
+- **GUI lifecycle owner:** the runtime that is allowed to terminate the application around an egui surface. The desktop
+  GUI is application-owned and retains application quit shortcuts. Plugin editors and the WASM surface are parent-owned;
+  they cannot turn a GUI shortcut into application shutdown because the DAW or browser owns that lifecycle.
 - **Latest-state GUI handoff:** a display update boundary where producers publish the newest BPM/histogram state through
   `GuiRemote`. It is not a durable queue. The GUI reads the latest shared state on its next frame, and contention paths
   prefer skipping/logging an update or frame over waiting for a blocking render lock.
@@ -94,7 +97,8 @@ flowchart LR
 ```
 
 The `gui` crate is deliberately shared and runtime-neutral. Plugin, desktop, and WASM mode each provide a config object
-that implements the GUI-facing accessors. Those config objects are where runtime-specific side effects start.
+that implements the GUI-facing accessors and explicitly declares the GUI lifecycle owner during bootstrap. Those config
+objects are where runtime-specific side effects start.
 
 ## Plugin Bootstrap
 
@@ -128,7 +132,8 @@ Who knows what:
   realtime-to-background ring producer.
 - `TaskExecutor` owns the plugin BPM model, dynamic config snapshot, ring consumer, optional `GuiRemote`, and optional
   tempo-controller TCP connection.
-- `GuiEditor` owns the plugin editor lifecycle and creates the GUI app when the editor opens.
+- `GuiEditor` creates the GUI app when the editor opens, while the DAW owns application and editor-window lifecycle
+  through the plugin API.
 - `GuiRemote` is passed by value across the runtime as a receiver/handle, but it only exposes the UI update surface.
 - The `task_executor_handoff` and `gui_editor_handoff` fields are one-shot NIH-plug handoff slots, not general nullable
   runtime state.

--- a/rust/crates/bpm/gui/src/app_builder.rs
+++ b/rust/crates/bpm/gui/src/app_builder.rs
@@ -5,21 +5,35 @@ use eframe::egui::Context;
 
 use crate::{BPMDetectionApp, app::BPMDetectionGUI};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GuiLifecycleOwner {
+    ApplicationRuntime,
+    ParentRuntime,
+}
+
+fn configure_quit_shortcuts(context: &Context, lifecycle_owner: GuiLifecycleOwner) {
+    if lifecycle_owner == GuiLifecycleOwner::ParentRuntime {
+        context.options_mut(|options| options.quit_shortcuts.clear());
+    }
+}
+
 pub struct AppBuilderShell {
     context_receiver: Arc<AtomicRefCell<Option<Context>>>,
     bpm_detection_gui: BPMDetectionGUI,
+    lifecycle_owner: GuiLifecycleOwner,
 }
 
 impl AppBuilderShell {
     pub(crate) fn new(
         context_receiver: Arc<AtomicRefCell<Option<Context>>>,
         bpm_detection_gui: BPMDetectionGUI,
+        lifecycle_owner: GuiLifecycleOwner,
     ) -> Self {
-        Self { context_receiver, bpm_detection_gui }
+        Self { context_receiver, bpm_detection_gui, lifecycle_owner }
     }
 
     pub fn with_config<Config>(self, base_config: Config) -> AppBuilder<Config> {
-        AppBuilder::new(self.context_receiver, self.bpm_detection_gui, base_config)
+        AppBuilder::new(self.context_receiver, self.bpm_detection_gui, base_config, self.lifecycle_owner)
     }
 }
 
@@ -27,10 +41,12 @@ pub struct AppBuilder<Config> {
     context_receiver: Arc<AtomicRefCell<Option<Context>>>,
     bpm_detection_gui: BPMDetectionGUI,
     base_config: Config,
+    lifecycle_owner: GuiLifecycleOwner,
 }
 
 impl<Config> AppBuilder<Config> {
     pub fn build(self, context: Context) -> BPMDetectionApp<Config> {
+        configure_quit_shortcuts(&context, self.lifecycle_owner);
         self.context_receiver.borrow_mut().replace(context);
         BPMDetectionApp { base_config: self.base_config, bpm_detection_gui: self.bpm_detection_gui }
     }
@@ -39,7 +55,12 @@ impl<Config> AppBuilder<Config> {
         context_receiver: Arc<AtomicRefCell<Option<Context>>>,
         bpm_detection_gui: BPMDetectionGUI,
         base_config: Config,
+        lifecycle_owner: GuiLifecycleOwner,
     ) -> Self {
-        Self { context_receiver, bpm_detection_gui, base_config }
+        Self { context_receiver, bpm_detection_gui, base_config, lifecycle_owner }
     }
 }
+
+#[cfg(test)]
+#[path = "../tests/unit/app_builder.rs"]
+mod tests;

--- a/rust/crates/bpm/gui/src/lib.rs
+++ b/rust/crates/bpm/gui/src/lib.rs
@@ -9,7 +9,7 @@
 use std::sync::{Arc, atomic::AtomicBool};
 
 pub use app::{BPMDetectionApp, BPMDetectionGUI};
-pub use app_builder::{AppBuilder, AppBuilderShell};
+pub use app_builder::{AppBuilder, AppBuilderShell, GuiLifecycleOwner};
 use atomic_float::AtomicF32;
 use atomic_refcell::AtomicRefCell;
 use bpm_detection_config::max_histogram_data_buffer_size;
@@ -35,7 +35,7 @@ mod config_ui;
 mod gui_remote;
 
 #[must_use]
-pub fn create_gui_shell() -> (GuiRemote, AppBuilderShell) {
+pub fn create_gui_shell(lifecycle_owner: GuiLifecycleOwner) -> (GuiRemote, AppBuilderShell) {
     let estimated_bpm = Arc::new(AtomicF32::new(f32::NAN));
     let daw_bpm = Arc::new(AtomicF32::new(f32::NAN));
     let should_save = Arc::new(AtomicBool::default());
@@ -71,11 +71,14 @@ pub fn create_gui_shell() -> (GuiRemote, AppBuilderShell) {
         daw_bpm,
         should_save,
     };
-    (gui_remote, AppBuilderShell::new(context_receiver, bpm_detection_gui))
+    (gui_remote, AppBuilderShell::new(context_receiver, bpm_detection_gui, lifecycle_owner))
 }
 
-pub fn create_gui<BaseConfig>(base_config: BaseConfig) -> (GuiRemote, AppBuilder<BaseConfig>) {
-    let (gui_remote, app_builder) = create_gui_shell();
+pub fn create_gui<BaseConfig>(
+    base_config: BaseConfig,
+    lifecycle_owner: GuiLifecycleOwner,
+) -> (GuiRemote, AppBuilder<BaseConfig>) {
+    let (gui_remote, app_builder) = create_gui_shell(lifecycle_owner);
     (gui_remote, app_builder.with_config(base_config))
 }
 

--- a/rust/crates/bpm/gui/tests/unit/app_builder.rs
+++ b/rust/crates/bpm/gui/tests/unit/app_builder.rs
@@ -1,0 +1,50 @@
+use eframe::egui::{Context, Event, Key, KeyboardShortcut, Modifiers, RawInput, ViewportCommand, ViewportId};
+
+use crate::{GuiLifecycleOwner, create_gui_shell};
+
+fn quit_shortcut() -> KeyboardShortcut {
+    KeyboardShortcut::new(Modifiers::COMMAND, Key::Q)
+}
+
+fn press_quit_shortcut(context: &Context) -> bool {
+    let output = context.run_ui(
+        RawInput {
+            events: vec![Event::Key {
+                key: Key::Q,
+                physical_key: None,
+                pressed: true,
+                repeat: false,
+                modifiers: Modifiers::COMMAND,
+            }],
+            ..Default::default()
+        },
+        |_| {},
+    );
+
+    output
+        .viewport_output
+        .get(&ViewportId::ROOT)
+        .is_some_and(|viewport| viewport.commands.contains(&ViewportCommand::Close))
+}
+
+#[test]
+fn application_owned_gui_can_request_application_quit() {
+    let context = Context::default();
+    context.options_mut(|options| options.quit_shortcuts = vec![quit_shortcut()]);
+
+    let (_, builder) = create_gui_shell(GuiLifecycleOwner::ApplicationRuntime);
+    let _app = builder.with_config(()).build(context.clone());
+
+    assert!(press_quit_shortcut(&context));
+}
+
+#[test]
+fn parent_owned_gui_cannot_request_application_quit() {
+    let context = Context::default();
+    context.options_mut(|options| options.quit_shortcuts = vec![quit_shortcut()]);
+
+    let (_, builder) = create_gui_shell(GuiLifecycleOwner::ParentRuntime);
+    let _app = builder.with_config(()).build(context.clone());
+
+    assert!(!press_quit_shortcut(&context));
+}

--- a/rust/crates/entrypoints/desktop/src/bin/desktop.rs
+++ b/rust/crates/entrypoints/desktop/src/bin/desktop.rs
@@ -7,7 +7,7 @@ use desktop::{
     live_parameters::DesktopBaseConfig,
 };
 use errors::{LogErrorWithExt, Result, initialize_logging, initialize_panic_handler};
-use gui::{create_gui_shell, start_gui};
+use gui::{GuiLifecycleOwner, create_gui_shell, start_gui};
 use mimalloc::MiMalloc;
 use sync::Mutex;
 
@@ -21,7 +21,7 @@ fn main() -> Result<()> {
     let config = DesktopConfig::new()?;
     let pending_controller_runtime = PendingDesktopControllerRuntime::new();
     let controller_commands = pending_controller_runtime.command_queue();
-    let (gui_remote, app_builder_shell) = create_gui_shell();
+    let (gui_remote, app_builder_shell) = create_gui_shell(GuiLifecycleOwner::ApplicationRuntime);
 
     let controller = start_desktop_controller(
         &config,

--- a/rust/crates/entrypoints/midi-bpm-detector-plugin/src/gui.rs
+++ b/rust/crates/entrypoints/midi-bpm-detector-plugin/src/gui.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, atomic::Ordering};
 
 use crossbeam::atomic::AtomicCell;
-use gui::{BPMDetectionApp, BPMDetectionConfig, GuiRemote, create_gui};
+use gui::{BPMDetectionApp, BPMDetectionConfig, GuiLifecycleOwner, GuiRemote, create_gui};
 use nih_plug::prelude::{AsyncExecutor, ParamSetter};
 use nih_plug_egui::{EguiState, egui::Context};
 use sync::{ArcAtomicBool, RwLock};
@@ -32,7 +32,7 @@ impl GuiEditor {
             self.force_evaluate_bpm_detection.clone(),
             self.params.clone(),
         );
-        let (gui_remote, gui_builder) = create_gui(live_config);
+        let (gui_remote, gui_builder) = create_gui(live_config, GuiLifecycleOwner::ParentRuntime);
         gui_remote.receive_keystrokes({
             let send_tempo = config.send_tempo.clone();
             Box::new(move |key| {

--- a/rust/crates/entrypoints/wasm/src/wasm.rs
+++ b/rust/crates/entrypoints/wasm/src/wasm.rs
@@ -18,7 +18,7 @@ use bpm_detection_core::{BPMDetection, TimedEvent, bpm_detection_receiver::BPMDe
 use chrono::Duration;
 use errors::{LogErrorWithExt, Result};
 use futures::{StreamExt, channel::mpsc::Sender};
-use gui::{GuiRemote, create_gui, start_gui};
+use gui::{GuiLifecycleOwner, GuiRemote, create_gui, start_gui};
 use instant::Instant;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen_futures::{JsFuture, js_sys::Promise};
@@ -61,7 +61,7 @@ pub fn run() -> Result<GuiRemoteWrapper> {
     let live_config = BaseConfig::new(redraw_sender.clone());
     let static_bpm_detection_config = live_config.config.bpm_detection.static_bpm_detection_config.clone();
     let mut dynamic_bpm_detection_config = live_config.config.bpm_detection.dynamic_bpm_detection_config.clone();
-    let (gui_remote, gui_builder) = create_gui(live_config);
+    let (gui_remote, gui_builder) = create_gui(live_config, GuiLifecycleOwner::ParentRuntime);
 
     wasm_bindgen_futures::spawn_local({
         let mut gui_remote = gui_remote.clone();


### PR DESCRIPTION
## What changed

- make GUI lifecycle ownership explicit at GUI bootstrap
- preserve egui's normal quit shortcut for the desktop application
- clear application quit shortcuts for DAW-hosted plugin editors and the browser-hosted WASM surface
- add regression tests for application-owned and parent-owned Cmd+Q behavior
- document the runtime ownership boundary

## Why

egui translates Cmd+Q into a root viewport close command. In the CLAP editor, that closes the embedded child GUI even though Bitwig still owns and displays the plugin window, leaving a blank editor until it is closed and reopened.

The GUI now only permits application-level quit shortcuts when its runtime actually owns the surrounding application. The desktop application therefore keeps its existing Cmd+Q behavior, while the CLAP editor cannot close itself behind the DAW's back.

## Validation

- live Bitwig CLAP check: Cmd+Q no longer blanks the editor; closing and reopening remains functional
- `cargo +nightly fmt --all -- --check`
- `cargo test --locked -p gui`
- `scripts/dev.sh check-native`
- `scripts/dev.sh check-wasm`
- `cargo check --manifest-path rust/Cargo.toml --locked --package midi-bpm-detector-plugin --lib --no-default-features --features clap`
- `cargo check --manifest-path rust/Cargo.toml --locked --package midi-bpm-detector-plugin --lib --no-default-features --features vst3`
- `git diff --check`
