### PR TITLE
build: repin nice-plug for Windows logging fix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "nice-log"
 version = "0.3.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "tracing-appender",
  "windows",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "nice-plug"
 version = "0.2.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-core"
 version = "0.2.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "atomic_float",
  "atomic_refcell",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-derive"
 version = "0.1.2"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-egui"
 version = "0.3.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "crossbeam",
  "egui",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-xtask"
 version = "0.1.1"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=211a6f32130dede2c493ddc8d88ea09f5be8e314#211a6f32130dede2c493ddc8d88ea09f5be8e314"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/rust/crates/entrypoints/midi-bpm-detector-plugin/Cargo.toml
+++ b/rust/crates/entrypoints/midi-bpm-detector-plugin/Cargo.toml
@@ -43,8 +43,8 @@ mimalloc = "0.1.52"
 wmidi = "4.0.11"
 
 toml = "1.1.2"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "211a6f32130dede2c493ddc8d88ea09f5be8e314", version = "0.2.0", default-features = false, features = ["assert_process_allocs"] }
-nice-plug-egui = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "211a6f32130dede2c493ddc8d88ea09f5be8e314", version = "0.3.0" }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false, features = ["assert_process_allocs"] }
+nice-plug-egui = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.3.0" }
 
 [lints]
 workspace = true

--- a/rust/crates/entrypoints/midi-bpm-detector-plugin/xtask/Cargo.toml
+++ b/rust/crates/entrypoints/midi-bpm-detector-plugin/xtask/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-nice-plug-xtask = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "211a6f32130dede2c493ddc8d88ea09f5be8e314", version = "0.1.1" }
+nice-plug-xtask = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.1.1" }

--- a/rust/crates/foundation/parameter-nice-plug/Cargo.toml
+++ b/rust/crates/foundation/parameter-nice-plug/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 parameter = { path = "../parameter" }
 parameter_nice_plug_macros = { package = "parameter-nice-plug-macros", path = "macros" }
 num-traits = "0.2.19"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "211a6f32130dede2c493ddc8d88ea09f5be8e314", version = "0.2.0", default-features = false }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/rust/crates/foundation/parameter-on-off-nice-plug/Cargo.toml
+++ b/rust/crates/foundation/parameter-on-off-nice-plug/Cargo.toml
@@ -9,7 +9,7 @@ parameter = { path = "../parameter" }
 parameter-on-off = { path = "../parameter-on-off" }
 parameter-nice-plug = { path = "../parameter-nice-plug" }
 num-traits = "0.2.19"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "211a6f32130dede2c493ddc8d88ea09f5be8e314", version = "0.2.0", default-features = false }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- repin every immutable `valsteen/nice-plug` dependency from `211a6f32130dede2c493ddc8d88ea09f5be8e314` to `d40fec783b978b73dadb3a8ce78e0eea6fde2ab2`
- update the six nice-plug workspace sources in `Cargo.lock`
- keep the diff limited to the four dependency manifests and the pin-only lockfile update

## Why

The first v0.2.0 release rehearsal on accepted `main` failed while building both [Windows CLAP and VST3 artifacts](https://github.com/valsteen/midi_bpm_detection/actions/runs/30178812441). The migrated nice-log implementation did not compile on Windows because its `Write` methods returned inconsistent match-arm types and its Windows stderr constructor referenced the removed `BufferedStandardStream`.

The shared fork fixes that regression in Codeberg commit [`d40fec783b978b73dadb3a8ce78e0eea6fde2ab2`](https://codeberg.org/valsteen/nice-plug/commit/d40fec783b978b73dadb3a8ce78e0eea6fde2ab2) by routing `Write` methods through the existing `writer()` adapter and using `io::stderr()` directly.

The non-publishing v0.2.0 rehearsal will restart from `main` after this PR is merged.

## Verification

- `cargo test --locked -p parameter-nice-plug -p parameter-on-off-nice-plug`
- `cargo test --locked -p midi-bpm-detector-plugin` (38 tests)
- locked host checks for CLAP-only and VST3-only plugin features
- `scripts/dev.sh verify-plugin` (format, Clippy, release CLAP bundle)
- isolated `x86_64-pc-windows-msvc` check of a consumer pinned to exact nice-log commit `d40fec7`
- `python3 -m unittest scripts/tests/test_release.py` (23 tests)
- `python3 scripts/release.py preflight v0.2.0`
- exact old/new pin closure and `git diff --check`

The full Windows plugin cross-check on this macOS host compiled the fixed nice-log crate, then stopped at the unrelated native `libmimalloc-sys` build because no Windows SDK headers are installed. GitHub’s Windows runners will exercise the complete artifact builds.
