### PR TITLE
build: repin nice-plug for logger initialization fix

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2969,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "nice-log"
 version = "0.3.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "tracing-appender",
  "windows",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "nice-plug"
 version = "0.2.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "anyhow",
  "anymap3",
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-core"
 version = "0.2.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "atomic_float",
  "atomic_refcell",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-derive"
 version = "0.1.2"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3045,7 +3045,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-egui"
 version = "0.3.0"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "crossbeam",
  "egui",
@@ -3059,7 +3059,7 @@ dependencies = [
 [[package]]
 name = "nice-plug-xtask"
 version = "0.1.1"
-source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=d40fec783b978b73dadb3a8ce78e0eea6fde2ab2#d40fec783b978b73dadb3a8ce78e0eea6fde2ab2"
+source = "git+https://codeberg.org/valsteen/nice-plug.git?rev=abd0b85ec2f744d22167eb730e53318b7fd020c1#abd0b85ec2f744d22167eb730e53318b7fd020c1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/rust/crates/entrypoints/midi-bpm-detector-plugin/Cargo.toml
+++ b/rust/crates/entrypoints/midi-bpm-detector-plugin/Cargo.toml
@@ -43,8 +43,8 @@ mimalloc = "0.1.52"
 wmidi = "4.0.11"
 
 toml = "1.1.2"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false, features = ["assert_process_allocs"] }
-nice-plug-egui = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.3.0" }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "abd0b85ec2f744d22167eb730e53318b7fd020c1", version = "0.2.0", default-features = false, features = ["assert_process_allocs"] }
+nice-plug-egui = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "abd0b85ec2f744d22167eb730e53318b7fd020c1", version = "0.3.0" }
 
 [lints]
 workspace = true

--- a/rust/crates/entrypoints/midi-bpm-detector-plugin/xtask/Cargo.toml
+++ b/rust/crates/entrypoints/midi-bpm-detector-plugin/xtask/Cargo.toml
@@ -8,4 +8,4 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-nice-plug-xtask = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.1.1" }
+nice-plug-xtask = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "abd0b85ec2f744d22167eb730e53318b7fd020c1", version = "0.1.1" }

--- a/rust/crates/foundation/parameter-nice-plug/Cargo.toml
+++ b/rust/crates/foundation/parameter-nice-plug/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 parameter = { path = "../parameter" }
 parameter_nice_plug_macros = { package = "parameter-nice-plug-macros", path = "macros" }
 num-traits = "0.2.19"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "abd0b85ec2f744d22167eb730e53318b7fd020c1", version = "0.2.0", default-features = false }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/rust/crates/foundation/parameter-on-off-nice-plug/Cargo.toml
+++ b/rust/crates/foundation/parameter-on-off-nice-plug/Cargo.toml
@@ -9,7 +9,7 @@ parameter = { path = "../parameter" }
 parameter-on-off = { path = "../parameter-on-off" }
 parameter-nice-plug = { path = "../parameter-nice-plug" }
 num-traits = "0.2.19"
-nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "d40fec783b978b73dadb3a8ce78e0eea6fde2ab2", version = "0.2.0", default-features = false }
+nice-plug = { git = "https://codeberg.org/valsteen/nice-plug.git", rev = "abd0b85ec2f744d22167eb730e53318b7fd020c1", version = "0.2.0", default-features = false }
 
 [lints]
 workspace = true


### PR DESCRIPTION
## Summary

- repin every immutable `valsteen/nice-plug` dependency from `d40fec783b978b73dadb3a8ce78e0eea6fde2ab2` to `abd0b85ec2f744d22167eb730e53318b7fd020c1`
- update the six nice-plug workspace sources in `Cargo.lock`
- keep the consumer diff limited to the four dependency manifests and a pin-only lockfile update

## Why

The second non-publishing v0.2.0 [release rehearsal](https://github.com/valsteen/midi_bpm_detection/actions/runs/30180100945) passed ten of eleven Rust artifact builds. Only Windows VST3 failed. Its `InitDll` expansion called generic `setup_logger()` without naming the plugin type, so Rust reported E0283 at `nice_export_vst3!(MidiBpmDetector)`.

Codeberg commit [`abd0b85ec2f744d22167eb730e53318b7fd020c1`](https://codeberg.org/valsteen/nice-plug/commit/abd0b85ec2f744d22167eb730e53318b7fd020c1) makes every generated logger call explicit:

- Windows VST3 invokes `setup_logger::<$plugin_ty>()`, removing the impossible generic inference.
- Unix/macOS VST3 and CLAP add the missing call parentheses, so they invoke the typed logger setup instead of merely constructing a function-item expression.

The v0.2.0 rehearsal will restart from accepted `main` after this PR is merged.

## Verification

- exact absence of the old revision and complete closure on `abd0b85ec2f744d22167eb730e53318b7fd020c1`
- `cargo test --locked -p parameter-nice-plug -p parameter-on-off-nice-plug`
- `cargo test --locked -p midi-bpm-detector-plugin` (38 tests)
- locked host CLAP-only and VST3-only plugin checks
- `scripts/dev.sh verify-plugin` (format, Clippy, release CLAP bundle)
- release VST3 bundle plus VST3-only export verification
- exact `x86_64-pc-windows-msvc` check of nice-plug's gain VST3 macro expansion at `abd0b85`
- `python3 -m unittest scripts/tests/test_release.py` (23 tests)
- `python3 scripts/release.py preflight v0.2.0`
- `git diff --check`

The complete consumer Windows VST3 cross-check on this macOS host reaches the fixed nice-plug graph, then stops in the unrelated native `libmimalloc-sys` build because Windows SDK headers are not installed locally. The post-merge rehearsal's Windows runner remains the complete artifact proof.
