### PR TITLE
Fix WASM keyboard tap routing around egui focus

### DIFF
--- a/docs/runtime-lifecycle.md
+++ b/docs/runtime-lifecycle.md
@@ -396,7 +396,8 @@ sequenceDiagram
     participant Model as BPMDetection
     participant Gui as GuiRemote
 
-    JS->>Wrapper: event_in(channel, note, velocity, timestamp)
+    JS->>Wrapper: event_in(...) or keyboard_event_in(timestamp, repeat)
+    Wrapper->>Wrapper: keyboard tap only if non-repeat and egui does not want input
     Wrapper->>Queue: QueueItem::Note(TimedEvent<NoteOn>)
     Gui->>Queue: QueueItem::StaticParameters / DynamicParameters
     Task->>Task: debounce note/config updates

--- a/rust/crates/entrypoints/wasm/index.html
+++ b/rust/crates/entrypoints/wasm/index.html
@@ -132,9 +132,8 @@
             _guiRemote = guiRemote;
 
             document.addEventListener("keydown", (event) => {
-                const timestamp = event.timeStamp;
-                guiRemote.event_in(0,0,80,timestamp);
-            });
+                guiRemote.keyboard_event_in(event.timeStamp, event.repeat);
+            }, { capture: true });
         }
 
         if ("requestMIDIAccess" in navigator) {

--- a/rust/crates/entrypoints/wasm/src/wasm.rs
+++ b/rust/crates/entrypoints/wasm/src/wasm.rs
@@ -35,14 +35,29 @@ async fn sleep(duration: StdDuration) {
     JsFuture::from(promise).await.ok();
 }
 
+pub(crate) fn keyboard_event_generates_tap(is_repeat: bool, egui_wants_keyboard_input: bool) -> bool {
+    !is_repeat && !egui_wants_keyboard_input
+}
+
 #[wasm_bindgen]
 pub struct GuiRemoteWrapper {
-    _gui_remote: GuiRemote, // javascript will hold this value, or the GUI will be dropped
+    gui_remote: GuiRemote, // javascript will hold this value, or the GUI will be dropped
     redraw_sender: Sender<QueueItem>,
 }
 
 #[wasm_bindgen]
 impl GuiRemoteWrapper {
+    pub fn keyboard_event_in(&mut self, timestamp: f64, is_repeat: bool) {
+        let Some(context) = self.gui_remote.get_context() else {
+            return;
+        };
+        if !keyboard_event_generates_tap(is_repeat, context.egui_wants_keyboard_input()) {
+            return;
+        }
+
+        self.event_in(0, 0, 80, timestamp);
+    }
+
     pub fn event_in(&mut self, channel: u8, note: u8, velocity: u8, timestamp: f64) {
         let note = TimedEvent {
             timestamp: Duration::milliseconds(timestamp as i64),
@@ -154,5 +169,5 @@ pub fn run() -> Result<GuiRemoteWrapper> {
 
     start_gui(gui_builder)?;
 
-    Ok(GuiRemoteWrapper { _gui_remote: gui_remote, redraw_sender })
+    Ok(GuiRemoteWrapper { gui_remote, redraw_sender })
 }

--- a/rust/crates/entrypoints/wasm/tests/unit/lib.rs
+++ b/rust/crates/entrypoints/wasm/tests/unit/lib.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 #[allow(clippy::module_name_repetitions)]
 use wasm_bindgen_test::*;
 
-use super::{BaseConfig, QueueItem, WASMConfig};
+use super::{BaseConfig, QueueItem, WASMConfig, wasm::keyboard_event_generates_tap};
 
 #[derive(Serialize, Deserialize)]
 pub struct Config {
@@ -80,4 +80,19 @@ fn dynamic_parameter_setter_queues_dynamic_parameters() {
         | QueueItem::DelayedDynamicUpdate
         | QueueItem::DelayedStaticUpdate => panic!("expected dynamic parameters"),
     }
+}
+
+#[wasm_bindgen_test]
+fn unclaimed_keyboard_event_generates_tap() {
+    assert!(keyboard_event_generates_tap(false, false));
+}
+
+#[wasm_bindgen_test]
+fn keyboard_event_owned_by_egui_does_not_generate_tap() {
+    assert!(!keyboard_event_generates_tap(false, true));
+}
+
+#[wasm_bindgen_test]
+fn repeated_keyboard_event_does_not_generate_tap() {
+    assert!(!keyboard_event_generates_tap(true, false));
 }


### PR DESCRIPTION
## Summary

- observe browser `keydown` events in the capture phase so ordinary keys such as Space can trigger taps
- preserve keyboard input for focused egui controls and suppress repeated-key taps
- document the focus gate in the existing WASM runtime flow

## Root cause

eframe handled recognized keys on the canvas and stopped propagation before the document-level bubble listener saw them. Modifier-only keys still bubbled, which made Ctrl appear to work while Space did not.

## Validation

- `scripts/dev.sh verify-wasm`
- 6 WASM tests passed
- optimized Trunk build and generated Pages asset consistency passed
- manually verified in the browser